### PR TITLE
Add Live Preview for Web mode and Code Execution for Multiple Languages with Judge0 Integration

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -39,6 +39,7 @@ export default function App() {
     useEffect(() => {
         const html = document.documentElement;
         html.setAttribute('data-theme', theme);
+        html.style.colorScheme = theme;
     }, [theme]);
 
     return (

--- a/client/src/api/judge0.js
+++ b/client/src/api/judge0.js
@@ -31,7 +31,9 @@ export async function executeCodeFetch({ language, sourceCode, stdin }) {
             `${API_URL}/submissions?base64_encoded=true`,
             {
                 method: 'POST',
-                headers: { 'content-type': 'application/json' },
+                headers: {
+                    'content-type': 'application/json',
+                },
                 body: JSON.stringify({
                     source_code: encodeToBase64(sourceCode),
                     language_id: language,
@@ -111,6 +113,11 @@ export async function executeCodeAxios({ language, sourceCode, stdin }) {
                 language_id: language,
                 stdin: encodeToBase64(stdin),
                 ...judge0Limits,
+            },
+            {
+                headers: {
+                    'content-type': 'application/json',
+                },
             }
         );
 
@@ -170,7 +177,9 @@ export function useExecuteCode() {
                 `${API_URL}/submissions?base64_encoded=true`,
                 {
                     method: 'POST',
-                    headers: { 'content-type': 'application/json' },
+                    headers: {
+                        'content-type': 'application/json',
+                    },
                     body: JSON.stringify({
                         source_code: encodeToBase64(sourceCode),
                         language_id: language,

--- a/client/src/api/judge0.js
+++ b/client/src/api/judge0.js
@@ -236,10 +236,14 @@ export function useExecuteCode() {
             return { stdout: output, stderr: error, time, memory, status };
         },
 
+        retry: 3,
+        retryDelay: 2000,
+
         onMutate: () => {
             dispatch(setIsRunning(true));
             dispatch(clearJudge0States());
         },
+
         onSuccess: (data) => {
             if (data.stdout) {
                 dispatch(setOutput(data.stdout));
@@ -261,6 +265,7 @@ export function useExecuteCode() {
             }
             dispatch(setStatus(data.status));
         },
+
         onError: (error) => {
             console.error(`Execution failed error: ${error.message}`);
             dispatch(setError(error.message));
@@ -272,6 +277,7 @@ export function useExecuteCode() {
                 })
             );
         },
+
         onSettled: () => {
             dispatch(setIsRunning(false));
         },

--- a/client/src/api/judge0.js
+++ b/client/src/api/judge0.js
@@ -12,13 +12,12 @@ import {
 const API_URL = '/api'; // Proxied to backend or Vercel function
 
 /**
- * Executes code using Judge0 CE API via backend proxy and dispatches results to Redux. Fetch variant
+ * Executes code using Judge0 CE API via backend proxy in dev mode or via vercel functions in prod. Fetch variant
  * @param {Object} params
  * @param {number} params.language - Language ID (50 for C, 54 for C++, 71 for Python).
  * @param {string} params.sourceCode - Code to execute.
  * @param {string} params.stdin - User-provided input.
- * @param {Function} params.dispatch - Redux dispatch function.
- * @returns {Promise<{ stdout: string, stderr: string }>}
+ * @returns {Object} stdout and stderr - Program output and errors if any
  */
 export async function executeCodeFetch({ language, sourceCode, stdin }) {
     try {
@@ -66,13 +65,12 @@ export async function executeCodeFetch({ language, sourceCode, stdin }) {
 }
 
 /**
- * Executes code using Judge0 CE API via backend proxy and dispatches results to Redux. Axios variant
+ * Executes code using Judge0 CE API via backend proxy in dev mode or via vercel functions in prod. Axios variant
  * @param {Object} params
  * @param {number} params.language - Language ID (50 for C, 54 for C++, 71 for Python).
  * @param {string} params.sourceCode - Code to execute.
  * @param {string} params.stdin - User-provided input.
- * @param {Function} params.dispatch - Redux dispatch function.
- * @returns {Promise<{ stdout: string, stderr: string }>}
+ * @returns {Object} stdout and stderr - Program output and errors if any
  */
 export async function executeCodeAxios({ language, sourceCode, stdin }) {
     try {

--- a/client/src/api/judge0.js
+++ b/client/src/api/judge0.js
@@ -1,5 +1,6 @@
 import { useMutation } from '@tanstack/react-query';
 import axios from 'axios';
+import { useDispatch } from 'react-redux';
 
 import { addNotification } from '../store/slices/uiSlice';
 import {
@@ -157,11 +158,12 @@ export async function executeCodeAxios({ language, sourceCode, stdin }) {
 }
 
 /**
- * Hook to execute code using TanStack Query.
- * @param {Function} dispatch - Redux dispatch function.
- * @returns {Object} Mutation hook with execute function.
+ * Hook to execute code through Judge0 using TanStack Query.
+ * @returns {Object} Mutation hook with execute mutation function and other props.
  */
-export function useExecuteCode(dispatch) {
+export function useExecuteCode() {
+    const dispatch = useDispatch();
+
     return useMutation({
         mutationFn: async ({ language, sourceCode, stdin }) => {
             const response = await fetch(
@@ -198,6 +200,8 @@ export function useExecuteCode(dispatch) {
                 result = await statusResponse.json();
                 if (result.status.id > 2) break;
             }
+
+            console.log(result);
 
             let {
                 stdout,

--- a/client/src/api/submissions.js
+++ b/client/src/api/submissions.js
@@ -10,17 +10,6 @@ const JUDGE0_API_KEY = process.env.JUDGE0_API_KEY;
  */
 export default async function handler(req, res) {
     try {
-        // Decode Base64 body if needed
-        const body = req.body;
-        if (body.source_code) {
-            body.source_code = Buffer.from(body.source_code, 'base64').toString(
-                'base64'
-            ); // Ensure valid Base64
-        }
-        if (body.stdin) {
-            body.stdin = Buffer.from(body.stdin, 'base64').toString('base64');
-        }
-
         const response = await fetch(
             `${JUDGE0_URL}/submissions${req.query.base64_encoded ? '?base64_encoded=true' : ''}&wait=false&fields=*`,
             {
@@ -47,6 +36,8 @@ export default async function handler(req, res) {
         const data = await response.json();
         return res.status(response.status).json(data);
     } catch (error) {
-        return res.status(500).json({ error: error.message });
+        return res
+            .status(error.response?.status || 500)
+            .json({ error: error.message });
     }
 }

--- a/client/src/api/submissions.js
+++ b/client/src/api/submissions.js
@@ -1,5 +1,3 @@
-import { Buffer } from 'node:buffer';
-
 const JUDGE0_URL = process.env.JUDGE0_URL || 'https://judge0-ce.p.rapidapi.com';
 const JUDGE0_API_KEY = process.env.JUDGE0_API_KEY;
 

--- a/client/src/api/submissions/[token].js
+++ b/client/src/api/submissions/[token].js
@@ -28,6 +28,8 @@ export default async function handler(req, res) {
         const data = await response.json();
         return res.status(response.status).json(data);
     } catch (error) {
-        return res.status(500).json({ error: error.message });
+        return res
+            .status(error.response?.status || 500)
+            .json({ error: error.message });
     }
 }

--- a/client/src/assets/icons/clear.svg
+++ b/client/src/assets/icons/clear.svg
@@ -1,0 +1,7 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Transformed by: SVG Repo Mixer Tools -->
+<svg width="100px" height="100px" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill="#000000" transform="matrix(1, 0, 0, -1, 0, 0)">
+<g id="SVGRepo_bgCarrier" stroke-width="0"/>
+<g id="SVGRepo_tracerCarrier" stroke-linecap="round" stroke-linejoin="round"/>
+<g id="SVGRepo_iconCarrier"> <path fill="none" stroke="#757575" stroke-width="2" d="M12,22 C17.5228475,22 22,17.5228475 22,12 C22,6.4771525 17.5228475,2 12,2 C6.4771525,2 2,6.4771525 2,12 C2,17.5228475 6.4771525,22 12,22 Z M5,5 L19,19"/> </g>
+</svg>

--- a/client/src/components/code-editor/CodeEditor.jsx
+++ b/client/src/components/code-editor/CodeEditor.jsx
@@ -14,6 +14,7 @@ import {
 import { Spinner } from '../componentsIndex';
 import { addNotification } from '../../store/slices/uiSlice';
 import { useDebounce } from '../../hooks/useDebounce';
+import { setCss, setHtml, setJs } from '../../store/slices/previewSlice';
 
 import nightOwlTheme from './themes/night-owl.json';
 import vsLight from './themes/custom-light.json';
@@ -22,8 +23,6 @@ import './CodeEditor.css';
 /**
  * CodeEditor component for rendering Monaco Editor with file selection.
  * @param {Object} props The props object for CodeEditor component
- * @param {string} props.language The programming language for the editor.
- * @param {string} props.codeContent The current code content to display.
  * @param {React.RefObject} editorRef The react ref for monaco editor.
  * @param {import('yjs').Text} props.yText - The Y.Text instance for the current file.
  * @param {import('y-websocket').Awareness} props.awareness - The Awareness instance for the current provider.
@@ -31,15 +30,16 @@ import './CodeEditor.css';
  * @returns {JSX.Element} The Monaco Editor.
  */
 export default function CodeEditor({
-    language,
-    codeContent,
     ref: editorRef,
     yjsResources,
     isYjsConnected,
 }) {
     const dispatch = useDispatch();
-    const { settings } = useSelector((state) => state.editor);
+    const { language, codeContent, settings } = useSelector(
+        (state) => state.editor
+    );
     const { theme } = useSelector((state) => state.ui);
+    const { executionMode } = useSelector((state) => state.execution);
     const { yDoc, yText, awareness } = yjsResources;
 
     const bindingRef = useRef(null); // To store the MonacoBinding instance for cleanup
@@ -59,12 +59,29 @@ export default function CodeEditor({
 
     const handleContentChange = useCallback(
         (value) => {
-            if (!yText) {
-                dispatch(setCodeContent(value));
-                dispatch(setSelectedFileContent(value));
+            if (yText) return;
+
+            dispatch(setCodeContent(value));
+            dispatch(setSelectedFileContent(value));
+
+            if (executionMode === 'preview') {
+                switch (language) {
+                    case 'html': {
+                        dispatch(setHtml(value));
+                        break;
+                    }
+                    case 'css': {
+                        dispatch(setCss(value));
+                        break;
+                    }
+                    case 'javascript': {
+                        dispatch(setJs(value));
+                        break;
+                    }
+                }
             }
         },
-        [dispatch, yText]
+        [dispatch, executionMode, language, yText]
     );
 
     const debouncedHandleContentChange = useDebounce(handleContentChange, 400);

--- a/client/src/components/code-editor/CodeEditor.jsx
+++ b/client/src/components/code-editor/CodeEditor.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import MonacoEditor from '@monaco-editor/react';
 import { MonacoBinding } from 'y-monaco';
@@ -57,12 +57,15 @@ export default function CodeEditor({
         '#009191',
     ];
 
-    function handleContentChange(value) {
-        if (!yText) {
-            dispatch(setCodeContent(value));
-            dispatch(setSelectedFileContent(value));
-        }
-    }
+    const handleContentChange = useCallback(
+        (value) => {
+            if (!yText) {
+                dispatch(setCodeContent(value));
+                dispatch(setSelectedFileContent(value));
+            }
+        },
+        [dispatch, yText]
+    );
 
     const debouncedHandleContentChange = useDebounce(handleContentChange, 400);
 

--- a/client/src/components/code-editor/CodeEditor.jsx
+++ b/client/src/components/code-editor/CodeEditor.jsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef } from 'react';
+import { memo, useCallback, useEffect, useRef } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import MonacoEditor from '@monaco-editor/react';
 import { MonacoBinding } from 'y-monaco';
@@ -29,11 +29,7 @@ import './CodeEditor.css';
  * @param {boolean} props.isInvited - Whether the session is invited for collaboration.
  * @returns {JSX.Element} The Monaco Editor.
  */
-export default function CodeEditor({
-    ref: editorRef,
-    yjsResources,
-    isYjsConnected,
-}) {
+function CodeEditor({ ref: editorRef, yjsResources, isYjsConnected }) {
     const dispatch = useDispatch();
     const { language, codeContent, settings } = useSelector(
         (state) => state.editor
@@ -608,3 +604,5 @@ export default function CodeEditor({
         </section>
     );
 }
+
+export default memo(CodeEditor);

--- a/client/src/components/componentsIndex.js
+++ b/client/src/components/componentsIndex.js
@@ -20,6 +20,7 @@ export { default as SaveAll } from './svg/SaveAll.jsx';
 export { default as Keyboard } from './svg/Keyboard.jsx';
 export { default as Reset } from './svg/Reset.jsx';
 export { default as Invite } from './svg/Invite.jsx';
+export { default as Clear } from './svg/Clear.jsx';
 
 // Auth Components
 export { default as AuthLayout } from '../components/auth-layout/AuthLayout.jsx';

--- a/client/src/components/componentsIndex.js
+++ b/client/src/components/componentsIndex.js
@@ -43,6 +43,7 @@ export { default as PreviewPanel } from './preview-panel/PreviewPanel.jsx';
 export { default as EditorToolbar } from './editor-toolbar/EditorToolbar.jsx';
 export { default as InviteAdminPanel } from './invite-panels/InviteAdminPanel.jsx';
 export { default as InvitePanel } from './invite-panels/InvitePanel.jsx';
+export { default as ModeSelector } from './mode-selector/ModeSelector.jsx';
 
 //UI Components
 export { default as Modal } from './modal/Modal.jsx';

--- a/client/src/components/editor-layout/EditorLayout.jsx
+++ b/client/src/components/editor-layout/EditorLayout.jsx
@@ -235,8 +235,6 @@ export default function EditorLayout({ projectId, isNewProject }) {
                     />
                 </div>
                 <CodeEditor
-                    language={language}
-                    codeContent={codeContent}
                     ref={editorRef}
                     yjsResources={yjsResources}
                     isYjsConnected={isYjsConnected}

--- a/client/src/components/editor-layout/EditorLayout.jsx
+++ b/client/src/components/editor-layout/EditorLayout.jsx
@@ -35,9 +35,7 @@ export default function EditorLayout({ projectId, isNewProject }) {
     );
     const { profile } = useSelector((state) => state.user);
     const { username } = profile || {};
-    const { output, error, isRunning, executionMode } = useSelector(
-        (state) => state.execution
-    );
+    const { executionMode } = useSelector((state) => state.execution);
     const { isPreviewVisible } = useSelector((state) => state.preview);
 
     // Layout and UI related States
@@ -299,11 +297,7 @@ export default function EditorLayout({ projectId, isNewProject }) {
                         aria-label="Resize Output and Input Panels"
                     />
                     <section className="max-h-full min-h-42 flex-1 md:h-[calc(100%-var(--input-height))]">
-                        <OutputPanel
-                            output={output}
-                            error={error}
-                            isRunning={isRunning}
-                        />
+                        <OutputPanel />
                     </section>
                 </section>
             )}

--- a/client/src/components/editor-layout/EditorLayout.jsx
+++ b/client/src/components/editor-layout/EditorLayout.jsx
@@ -150,11 +150,6 @@ export default function EditorLayout({ projectId, isNewProject }) {
         username,
     });
 
-    //TODO move this in its right place
-    const handleInputChange = (e) => {
-        setInput(DOMPurify.sanitize(e.target.value));
-    };
-
     //TODO remove this when deploying, only for dev cuz of strict mode
     const isMountedRef = useRef(false);
 
@@ -295,10 +290,7 @@ export default function EditorLayout({ projectId, isNewProject }) {
             ) : (
                 <section className="flex w-full flex-col md:w-[calc(100%-var(--editor-width))] md:min-w-64 md:flex-1">
                     <section className="max-h-full min-h-40 md:h-[var(--input-height)]">
-                        <InputPanel
-                            input={input}
-                            onInputChange={handleInputChange}
-                        />
+                        <InputPanel input={input} setInput={setInput} />
                     </section>
                     <div
                         className="hidden h-1 cursor-ns-resize bg-gray-300 hover:bg-blue-600 active:bg-blue-600 md:block dark:bg-gray-500"

--- a/client/src/components/editor-layout/EditorLayout.jsx
+++ b/client/src/components/editor-layout/EditorLayout.jsx
@@ -35,11 +35,10 @@ export default function EditorLayout({ projectId, isNewProject }) {
     );
     const { profile } = useSelector((state) => state.user);
     const { username } = profile || {};
-    const { executionMode } = useSelector((state) => state.execution);
+    const { input, executionMode } = useSelector((state) => state.execution);
     const { isPreviewVisible } = useSelector((state) => state.preview);
 
     // Layout and UI related States
-    const [input, setInput] = useState('');
     const [editorWidth, setEditorWidth] = useState(66.67); // 2/3 of screen
     const [inputHeight, setInputHeight] = useState(50); // 50% of right panel
     const [consoleHeight, setConsoleHeight] = useState(20); // 20% of right panel
@@ -288,7 +287,7 @@ export default function EditorLayout({ projectId, isNewProject }) {
             ) : (
                 <section className="flex w-full flex-col md:w-[calc(100%-var(--editor-width))] md:min-w-64 md:flex-1">
                     <section className="max-h-full min-h-40 md:h-[var(--input-height)]">
-                        <InputPanel input={input} setInput={setInput} />
+                        <InputPanel />
                     </section>
                     <div
                         className="hidden h-1 cursor-ns-resize bg-gray-300 hover:bg-blue-600 active:bg-blue-600 md:block dark:bg-gray-500"

--- a/client/src/components/editor-toolbar/EditorToolbar.jsx
+++ b/client/src/components/editor-toolbar/EditorToolbar.jsx
@@ -47,6 +47,8 @@ function EditorToolbar({
     // collaborators,
     yjsResources,
     setIsYjsConnected,
+    showPreview,
+    setShowPreview,
 }) {
     const [isAdminPanelOpen, setIsAdminPanelOpen] = useState(false);
     const inviteButtonRef = useRef(null);
@@ -92,6 +94,24 @@ function EditorToolbar({
                         aria-label="Run code"
                     >
                         <Run />
+                    </button>
+                </Tooltip>
+                <Tooltip
+                    content={
+                        <div className="flex flex-col items-center justify-center">
+                            <p>Preview Mode</p>
+                            <p>HTML/CSS/JS</p>
+                        </div>
+                    }
+                >
+                    <button
+                        onClick={() => setShowPreview((prev) => !prev)}
+                        className="cursor-pointer rounded-full px-3 pt-2 pb-1.5 text-xs hover:bg-gray-300 focus:bg-gray-300 focus:outline-1 focus:outline-offset-2 focus:outline-green-400 dark:hover:bg-[#2b2b44] dark:focus:bg-[#2b2b44]"
+                        aria-label={
+                            showPreview ? 'Hide preview' : 'Show preview'
+                        }
+                    >
+                        {showPreview ? 'Hide Preview' : 'Show Preview'}
                     </button>
                 </Tooltip>
                 <Tooltip content={'Reset code'}>

--- a/client/src/components/editor-toolbar/EditorToolbar.jsx
+++ b/client/src/components/editor-toolbar/EditorToolbar.jsx
@@ -145,40 +145,44 @@ function EditorToolbar({
                         <Keyboard width={1.7} height={1.7} />
                     </button>
                 </Tooltip>
-                <Tooltip content={'Invite'}>
-                    <button
-                        ref={inviteButtonRef}
-                        onClick={handleInviteClick}
-                        className="cursor-pointer rounded-full px-2.5 py-1.5 hover:bg-gray-300 focus:bg-gray-300 focus:outline-1 focus:outline-offset-2 focus:outline-gray-500 dark:hover:bg-[#2b2b44] dark:focus:bg-[#2b2b44]"
-                        aria-label="Invite collaborators"
-                    >
-                        <Invite width={1.8} height={1.8} />
-                    </button>
-                </Tooltip>
-                <AnimatePresence>
-                    {isAdmin && isAdminPanelOpen && (
-                        <InviteAdminPanel
-                            isOpen={isAdminPanelOpen}
-                            key={'InviteAdminPanel'}
-                            onClose={closeAdminPanel}
-                            awareness={yjsResources.awareness}
-                            onEndSession={handleEndSession}
-                            onCopyLink={handleInvite}
-                            anchorRef={inviteButtonRef}
-                        />
-                    )}{' '}
-                    {!isAdmin && isAdminPanelOpen && (
-                        <InvitePanel
-                            isOpen={isAdminPanelOpen}
-                            key={'InvitePanel'}
-                            onClose={closeAdminPanel}
-                            awareness={yjsResources.awareness}
-                            onEndSession={handleEndSession}
-                            onCopyLink={handleInvite}
-                            anchorRef={inviteButtonRef}
-                        />
-                    )}
-                </AnimatePresence>
+                {executionMode === 'judge0' && (
+                    <>
+                        <Tooltip content={'Invite'}>
+                            <button
+                                ref={inviteButtonRef}
+                                onClick={handleInviteClick}
+                                className="cursor-pointer rounded-full px-2.5 py-1.5 hover:bg-gray-300 focus:bg-gray-300 focus:outline-1 focus:outline-offset-2 focus:outline-gray-500 dark:hover:bg-[#2b2b44] dark:focus:bg-[#2b2b44]"
+                                aria-label="Invite collaborators"
+                            >
+                                <Invite width={1.8} height={1.8} />
+                            </button>
+                        </Tooltip>
+                        <AnimatePresence>
+                            {isAdmin && isAdminPanelOpen && (
+                                <InviteAdminPanel
+                                    isOpen={isAdminPanelOpen}
+                                    key={'InviteAdminPanel'}
+                                    onClose={closeAdminPanel}
+                                    awareness={yjsResources.awareness}
+                                    onEndSession={handleEndSession}
+                                    onCopyLink={handleInvite}
+                                    anchorRef={inviteButtonRef}
+                                />
+                            )}{' '}
+                            {!isAdmin && isAdminPanelOpen && (
+                                <InvitePanel
+                                    isOpen={isAdminPanelOpen}
+                                    key={'InvitePanel'}
+                                    onClose={closeAdminPanel}
+                                    awareness={yjsResources.awareness}
+                                    onEndSession={handleEndSession}
+                                    onCopyLink={handleInvite}
+                                    anchorRef={inviteButtonRef}
+                                />
+                            )}
+                        </AnimatePresence>
+                    </>
+                )}
             </div>
         </div>
     );

--- a/client/src/components/editor-toolbar/EditorToolbar.jsx
+++ b/client/src/components/editor-toolbar/EditorToolbar.jsx
@@ -1,5 +1,6 @@
 import { memo, useCallback, useRef, useState } from 'react';
 import { AnimatePresence } from 'framer-motion';
+import { useSelector } from 'react-redux';
 
 import {
     Format,
@@ -8,6 +9,7 @@ import {
     InvitePanel,
     Keyboard,
     LanguageSelector,
+    ModeSelector,
     Reset,
     Run,
     Save,
@@ -47,9 +49,9 @@ function EditorToolbar({
     // collaborators,
     yjsResources,
     setIsYjsConnected,
-    showPreview,
-    setShowPreview,
 }) {
+    const { executionMode } = useSelector((state) => state.execution);
+
     const [isAdminPanelOpen, setIsAdminPanelOpen] = useState(false);
     const inviteButtonRef = useRef(null);
 
@@ -69,7 +71,7 @@ function EditorToolbar({
 
     return (
         <div
-            className="flex w-full flex-grow justify-center pb-4"
+            className="flex w-full flex-grow justify-center gap-1 pb-4"
             role="toolbar"
             aria-label="Editor toolbar"
         >
@@ -77,6 +79,7 @@ function EditorToolbar({
                 selectedLanguage={language}
                 onLanguageChange={handleLanguageChange}
             />
+            <ModeSelector />
             <div className="flex w-full items-center justify-center gap-1 sm:gap-8 md:justify-end md:gap-1.5">
                 <Tooltip content={'Format code'}>
                     <button
@@ -87,33 +90,17 @@ function EditorToolbar({
                         <Format width={1.6} height={1.6} />
                     </button>
                 </Tooltip>
-                <Tooltip content={'Run code'}>
-                    <button
-                        onClick={handleRunCode}
-                        className="cursor-pointer rounded-full px-3 pt-2 pb-1.5 hover:bg-gray-300 focus:bg-gray-300 focus:outline-1 focus:outline-offset-2 focus:outline-green-400 dark:hover:bg-[#2b2b44] dark:focus:bg-[#2b2b44]"
-                        aria-label="Run code"
-                    >
-                        <Run />
-                    </button>
-                </Tooltip>
-                <Tooltip
-                    content={
-                        <div className="flex flex-col items-center justify-center">
-                            <p>Preview Mode</p>
-                            <p>HTML/CSS/JS</p>
-                        </div>
-                    }
-                >
-                    <button
-                        onClick={() => setShowPreview((prev) => !prev)}
-                        className="cursor-pointer rounded-full px-3 pt-2 pb-1.5 text-xs hover:bg-gray-300 focus:bg-gray-300 focus:outline-1 focus:outline-offset-2 focus:outline-green-400 dark:hover:bg-[#2b2b44] dark:focus:bg-[#2b2b44]"
-                        aria-label={
-                            showPreview ? 'Hide preview' : 'Show preview'
-                        }
-                    >
-                        {showPreview ? 'Hide Preview' : 'Show Preview'}
-                    </button>
-                </Tooltip>
+                {executionMode === 'judge0' && (
+                    <Tooltip content={'Run code'}>
+                        <button
+                            onClick={handleRunCode}
+                            className="cursor-pointer rounded-full px-3 pt-2 pb-1.5 hover:bg-gray-300 focus:bg-gray-300 focus:outline-1 focus:outline-offset-2 focus:outline-green-400 dark:hover:bg-[#2b2b44] dark:focus:bg-[#2b2b44]"
+                            aria-label="Run code"
+                        >
+                            <Run />
+                        </button>
+                    </Tooltip>
+                )}
                 <Tooltip content={'Reset code'}>
                     <button
                         onClick={handleResetCode}

--- a/client/src/components/input-panel/InputPanel.jsx
+++ b/client/src/components/input-panel/InputPanel.jsx
@@ -21,7 +21,7 @@ function InputPanel({ input, setInput }) {
             role="region"
             aria-label="Input panel"
         >
-            <label htmlFor="stdin" className="mb-2 text-lg font-semibold">
+            <label htmlFor="stdin" className="mb-2 text-sm font-semibold">
                 Input
             </label>
             <textarea

--- a/client/src/components/input-panel/InputPanel.jsx
+++ b/client/src/components/input-panel/InputPanel.jsx
@@ -1,12 +1,20 @@
 import { memo } from 'react';
+import DOMPurify from 'dompurify';
 
 /**
  * InputPanel component for providing stdin for code execution.
- * @param {string} input - The current input vaue.
- * @param {Function} onInputChange - Callback for input changes.
+ * @param {Object} props - The component props.
+ * @param {React.ComponentState<string>} props.input - The current input state value.
+ * @param {React.SetStateAction<Function>} props.setInput - State setter for input.
  * @returns {JSX.Element} The input panel.
  */
-function InputPanel({ input, onInputChange }) {
+function InputPanel({ input, setInput }) {
+    function handleInputChange(event) {
+        const sanitizedInput = DOMPurify.sanitize(event.target.value);
+
+        setInput(sanitizedInput);
+    }
+
     return (
         <div
             className="flex h-full max-h-full flex-col gap-1 p-4 text-gray-800 dark:bg-[#222233] dark:text-gray-200"
@@ -19,7 +27,7 @@ function InputPanel({ input, onInputChange }) {
             <textarea
                 id="stdin"
                 value={input}
-                onChange={(e) => onInputChange(e.target.value)}
+                onChange={handleInputChange}
                 className="h-24 min-h-11 w-full rounded border border-gray-500 bg-gray-100 p-2 transition-shadow duration-300 focus:ring-2 focus:ring-blue-500 focus:outline-none dark:bg-[#2b2b44] dark:text-white"
                 placeholder="Enter input for your code (stdin)..."
                 aria-label="Enter input for code execution"

--- a/client/src/components/input-panel/InputPanel.jsx
+++ b/client/src/components/input-panel/InputPanel.jsx
@@ -1,18 +1,21 @@
 import { memo } from 'react';
 import DOMPurify from 'dompurify';
+import { useDispatch, useSelector } from 'react-redux';
+
+import { setInput } from '../../store/slices/executionSlice';
 
 /**
  * InputPanel component for providing stdin for code execution.
- * @param {Object} props - The component props.
- * @param {React.ComponentState<string>} props.input - The current input state value.
- * @param {React.SetStateAction<Function>} props.setInput - State setter for input.
  * @returns {JSX.Element} The input panel.
  */
-function InputPanel({ input, setInput }) {
+function InputPanel() {
+    const dispatch = useDispatch();
+    const { input } = useSelector((state) => state.execution);
+
     function handleInputChange(event) {
         const sanitizedInput = DOMPurify.sanitize(event.target.value);
 
-        setInput(sanitizedInput);
+        dispatch(setInput(sanitizedInput));
     }
 
     return (

--- a/client/src/components/language-selector/LanguageSelector.jsx
+++ b/client/src/components/language-selector/LanguageSelector.jsx
@@ -107,7 +107,7 @@ export default function LanguageSelector({
                                         setIsOpen(false);
                                     }
                                 }}
-                                className={`cursor-pointer px-3 py-2 text-sm focus:outline-1 focus:-outline-offset-1 focus:outline-gray-800 dark:hover:bg-[#1A1B26] dark:focus:outline-white ${selectedLanguage === language.value ? 'bg-gray-400 dark:bg-[#2e3044]' : ''}`}
+                                className={`cursor-pointer px-3 py-2 text-sm focus:outline-1 focus:-outline-offset-1 focus:outline-gray-800 dark:hover:bg-[#1A1B26] dark:focus:outline-white ${selectedLanguage === language.value ? '' : 'bg-gray-400 dark:bg-[#2e3044]'}`}
                                 role="option"
                                 aria-selected={
                                     selectedLanguage === language.value

--- a/client/src/components/mode-selector/ModeSelector.jsx
+++ b/client/src/components/mode-selector/ModeSelector.jsx
@@ -1,0 +1,144 @@
+import { useState, useRef, useEffect } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import { useDispatch, useSelector } from 'react-redux';
+
+import { setExecutionMode } from '../../store/slices/executionSlice';
+import { setIsPreviewVisible } from '../../store/slices/previewSlice';
+
+/**
+ * ModeSelector component for selecting execution mode between Judge0 and Web(HTML, CSS and JS)Preview.
+ * @param {string} selectedLanguage - The currently selected language.
+ * @param {Function} onLanguageChange - Callback to handle language changes.
+ * @returns {JSX.Element} The mode selection dropdown.
+ */
+export default function ModeSelector() {
+    const [isOpen, setIsOpen] = useState(false);
+    const dropdownRef = useRef(null);
+
+    const dispatch = useDispatch();
+    const { executionMode } = useSelector((state) => state.execution);
+
+    // Close dropdown when clicking outside
+    useEffect(() => {
+        function handleClickOutside(event) {
+            if (
+                dropdownRef.current &&
+                !dropdownRef.current.contains(event.target)
+            ) {
+                setIsOpen(false);
+            }
+        }
+
+        // Attach to a parent container (e.g., EditorLayout) instead of document for better performance
+        const parentContainer = dropdownRef.current?.closest(
+            '.editor-layout-container'
+        );
+        parentContainer?.addEventListener('mousedown', handleClickOutside);
+        return () =>
+            parentContainer?.removeEventListener(
+                'mousedown',
+                handleClickOutside
+            );
+    }, []);
+
+    // Handle keyboard navigation
+    function handleKeyDown(event) {
+        if (event.key === 'Escape') {
+            setIsOpen(false);
+        }
+    }
+
+    function toggleExecutionModeSelector() {
+        setIsOpen((isOpen) => !isOpen);
+    }
+
+    return (
+        <div
+            className="relative inline-block"
+            ref={dropdownRef}
+            role="none"
+            onKeyDown={handleKeyDown}
+        >
+            <button
+                onClick={toggleExecutionModeSelector}
+                className="flex w-fit min-w-30 cursor-pointer items-center justify-center rounded border border-gray-400/90 bg-gray-300 px-3 py-2 text-xs font-medium whitespace-nowrap text-gray-800 focus:outline-1 focus:outline-offset-2 focus:outline-gray-400 dark:bg-[#222233] dark:text-white dark:hover:bg-[#2e3044] dark:focus:bg-[#2e3044]"
+                aria-haspopup="listbox"
+                aria-expanded={isOpen}
+                aria-label="Select execution mode"
+            >
+                {executionMode === 'judge0' ? 'Compiler' : 'Web Preview'}
+                <svg
+                    className={`ml-2 h-5 w-5 transition-transform ${isOpen ? 'rotate-180' : ''}`}
+                    xmlns="http://www.w3.org/2000/svg"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                >
+                    <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={2}
+                        d="M19 9l-7 7-7-7"
+                    />
+                </svg>
+            </button>
+
+            <AnimatePresence>
+                {isOpen && (
+                    <motion.ul
+                        initial={{ opacity: 0, y: 10 }}
+                        animate={{ opacity: 1, y: 0 }}
+                        exit={{ opacity: 0, y: -10 }}
+                        transition={{ duration: 0.3 }}
+                        className="absolute z-10 mt-1 w-6/6 rounded border border-gray-400 bg-gray-300 shadow-lg dark:border-gray-300 dark:bg-[#222233]"
+                        role="listbox"
+                        aria-label="Programming languages"
+                    >
+                        <li
+                            key={'judge0'}
+                            onClick={() => {
+                                dispatch(setExecutionMode('judge0'));
+                                dispatch(setIsPreviewVisible(false));
+                                setIsOpen(false);
+                            }}
+                            onKeyDown={(e) => {
+                                if (e.key === 'Enter' || e.key === ' ') {
+                                    dispatch(setExecutionMode('judge0'));
+                                    dispatch(setIsPreviewVisible(false));
+                                    setIsOpen(false);
+                                }
+                            }}
+                            className={`cursor-pointer px-3 py-2 text-sm focus:outline-1 focus:-outline-offset-1 focus:outline-gray-800 dark:hover:bg-[#1A1B26] dark:focus:outline-white ${executionMode === 'judge0' ? 'bg-gray-400 dark:bg-[#2e3044]' : ''}`}
+                            role="option"
+                            aria-selected={executionMode === 'judge0'}
+                            tabIndex={0}
+                        >
+                            {'Compiler'}
+                        </li>
+                        <li
+                            key={'preview'}
+                            onClick={() => {
+                                dispatch(setExecutionMode('preview'));
+                                dispatch(setIsPreviewVisible(true));
+                                setIsOpen(false);
+                            }}
+                            onKeyDown={(e) => {
+                                if (e.key === 'Enter' || e.key === ' ') {
+                                    dispatch(setExecutionMode('preview'));
+                                    dispatch(setIsPreviewVisible(true));
+                                    setIsOpen(false);
+                                }
+                            }}
+                            className={`cursor-pointer px-3 py-2 text-sm focus:outline-1 focus:-outline-offset-1 focus:outline-gray-800 dark:hover:bg-[#1A1B26] dark:focus:outline-white ${executionMode === 'preview' ? 'bg-gray-400 dark:bg-[#2e3044]' : ''}`}
+                            role="option"
+                            aria-selected={executionMode === 'preview'}
+                            tabIndex={0}
+                        >
+                            {'Web Preview'}
+                        </li>
+                    </motion.ul>
+                )}
+            </AnimatePresence>
+        </div>
+    );
+}

--- a/client/src/components/mode-selector/ModeSelector.jsx
+++ b/client/src/components/mode-selector/ModeSelector.jsx
@@ -7,8 +7,6 @@ import { setIsPreviewVisible } from '../../store/slices/previewSlice';
 
 /**
  * ModeSelector component for selecting execution mode between Judge0 and Web(HTML, CSS and JS)Preview.
- * @param {string} selectedLanguage - The currently selected language.
- * @param {Function} onLanguageChange - Callback to handle language changes.
  * @returns {JSX.Element} The mode selection dropdown.
  */
 export default function ModeSelector() {

--- a/client/src/components/mode-selector/ModeSelector.jsx
+++ b/client/src/components/mode-selector/ModeSelector.jsx
@@ -108,7 +108,7 @@ export default function ModeSelector() {
                                     setIsOpen(false);
                                 }
                             }}
-                            className={`cursor-pointer px-3 py-2 text-sm focus:outline-1 focus:-outline-offset-1 focus:outline-gray-800 dark:hover:bg-[#1A1B26] dark:focus:outline-white ${executionMode === 'judge0' ? 'bg-gray-400 dark:bg-[#2e3044]' : ''}`}
+                            className={`cursor-pointer px-3 py-2 text-sm focus:outline-1 focus:-outline-offset-1 focus:outline-gray-800 dark:hover:bg-[#1A1B26] dark:focus:outline-white ${executionMode === 'judge0' ? '' : 'bg-gray-400 dark:bg-[#2e3044]'}`}
                             role="option"
                             aria-selected={executionMode === 'judge0'}
                             tabIndex={0}
@@ -129,7 +129,7 @@ export default function ModeSelector() {
                                     setIsOpen(false);
                                 }
                             }}
-                            className={`cursor-pointer px-3 py-2 text-sm focus:outline-1 focus:-outline-offset-1 focus:outline-gray-800 dark:hover:bg-[#1A1B26] dark:focus:outline-white ${executionMode === 'preview' ? 'bg-gray-400 dark:bg-[#2e3044]' : ''}`}
+                            className={`cursor-pointer px-3 py-2 text-sm focus:outline-1 focus:-outline-offset-1 focus:outline-gray-800 dark:hover:bg-[#1A1B26] dark:focus:outline-white ${executionMode === 'preview' ? '' : 'bg-gray-400 dark:bg-[#2e3044]'}`}
                             role="option"
                             aria-selected={executionMode === 'preview'}
                             tabIndex={0}

--- a/client/src/components/output-panel/OutputPanel.jsx
+++ b/client/src/components/output-panel/OutputPanel.jsx
@@ -1,25 +1,80 @@
 import { memo } from 'react';
+import { useSelector } from 'react-redux';
+
+import { Spinner } from '../componentsIndex';
+import { judge0Verdicts } from '../../conf/judge0Config';
 
 /**
  * OutputPanel component for displaying stdout from code execution.
- * @param {string} output - The output to display.
  * @returns {JSX.Element} The output panel.
  */
-function OutputPanel({ output }) {
+function OutputPanel() {
+    const { output, error, isRunning, status, time, memory } = useSelector(
+        (state) => state.execution
+    );
+
+    //TODO Add green/red bg
+
+    if (isRunning) {
+        return (
+            <div className="flex h-full w-full items-center justify-center">
+                <Spinner size="4" />
+            </div>
+        );
+    }
+
     return (
         <div
             className="flex h-full max-h-full flex-col overflow-auto p-4 dark:bg-[#222233]"
             role="region"
             aria-label="Output panel"
         >
-            <h3 className="mb-2 text-lg font-semibold">Output</h3>
-            <pre
-                className="max-h-full flex-1 break-words whitespace-pre-wrap"
-                aria-live="polite"
-                aria-label="Code execution output"
-            >
-                {output || 'Run your code to see the output here.'}
-            </pre>
+            <h3 className="mb-2 text-sm font-semibold">Output</h3>
+
+            {output || error || status ? (
+                <div className="flex flex-col gap-4 rounded-md border border-gray-600 p-2">
+                    <p
+                        className={`rounded-md p-2 ${output ? 'bg-green-400/40' : error ? 'bg-red-500/40' : 'bg-gray-100 dark:bg-[#2b2b44]'}`}
+                    >
+                        <span className="text-xl font-bold">Status: </span>{' '}
+                        {judge0Verdicts[status?.id] ?? status?.description}
+                    </p>
+
+                    {(output || status) && (
+                        <div className="flex">
+                            {time && (
+                                <div className="flex flex-col border-r border-r-gray-600 px-2">
+                                    <p className="font-bold">Time:</p>
+                                    <p>{`${time} seconds`}</p>
+                                </div>
+                            )}
+                            {memory && (
+                                <div className="flex flex-col px-2">
+                                    <p className="font-bold">Memory:</p>
+                                    <p>{`${(memory / 1024).toFixed(3)} MB`}</p>
+                                </div>
+                            )}
+                        </div>
+                    )}
+
+                    <div className="flex flex-col gap-2">
+                        <p className="font-bold">
+                            {output ? 'Your output:' : 'Error:'}
+                        </p>
+                        <pre
+                            className={`max-h-full min-h-8 flex-1 rounded-md bg-gray-100 p-2 break-words whitespace-pre-wrap dark:bg-[#2b2b44]`}
+                            aria-live="polite"
+                            aria-label="Code execution output"
+                        >
+                            {output || error || 'No output to show'}
+                        </pre>
+                    </div>
+                </div>
+            ) : (
+                <p className="font-mono">
+                    Run your code to see the output here.
+                </p>
+            )}
         </div>
     );
 }

--- a/client/src/components/output-panel/OutputPanel.jsx
+++ b/client/src/components/output-panel/OutputPanel.jsx
@@ -13,8 +13,6 @@ function OutputPanel() {
         (state) => state.execution
     );
 
-    //TODO Add green/red bg
-
     if (isRunning) {
         return (
             <div className="flex h-full w-full items-center justify-center">
@@ -35,13 +33,19 @@ function OutputPanel() {
                 <div className="flex flex-col gap-4 rounded-md border border-gray-600 p-2">
                     <p
                         className={`rounded-md p-2 ${output ? 'bg-green-400/40' : error ? 'bg-red-500/40' : 'bg-gray-100 dark:bg-[#2b2b44]'}`}
+                        aria-live={status?.id === 3 ? 'polite' : 'assertive'}
+                        aria-label="Executed code status"
                     >
                         <span className="text-xl font-bold">Status: </span>{' '}
                         {judge0Verdicts[status?.id] ?? status?.description}
                     </p>
 
                     {(output || status) && (
-                        <div className="flex">
+                        <div
+                            className="flex"
+                            aria-live="polite"
+                            aria-label="Executed code parameters"
+                        >
                             {time && (
                                 <div className="flex flex-col border-r border-r-gray-600 px-2">
                                     <p className="font-bold">Time:</p>
@@ -65,6 +69,7 @@ function OutputPanel() {
                             className={`max-h-full min-h-8 flex-1 rounded-md bg-gray-100 p-2 break-words whitespace-pre-wrap dark:bg-[#2b2b44]`}
                             aria-live="polite"
                             aria-label="Code execution output"
+                            lang="en"
                         >
                             {output || error || 'No output to show'}
                         </pre>

--- a/client/src/components/preview-panel/PreviewPanel.jsx
+++ b/client/src/components/preview-panel/PreviewPanel.jsx
@@ -2,18 +2,18 @@ import { useEffect, useRef } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import DOMPurify from 'dompurify';
 
-import { addNotification } from '../../store/slices/uiSlice';
 import {
+    clearConsoleLogs,
     setConsoleLogs,
     setIsConsoleVisible,
 } from '../../store/slices/previewSlice';
+import { Clear } from '../componentsIndex';
 
 export default function PreviewPanel({
     handleVerticalMouseDown,
     ref: previewContainerRef,
 }) {
     const dispatch = useDispatch();
-    const { codeContent } = useSelector((state) => state.editor);
     const { html, css, js, consoleLogs, isConsoleVisible } = useSelector(
         (state) => state.preview
     );
@@ -23,71 +23,111 @@ export default function PreviewPanel({
         const iframe = iframeRef.current;
         if (!iframe) return;
 
-        const sanitizedHTML = DOMPurify.sanitize(html || '');
+        const allowedOrigins = [
+            'http://localhost:5173',
+            'https://bytetogether.vercel.app', //TODO Update prod URL
+        ];
+
+        const isProduction = import.meta.env.PROD;
+
+        const parser = new DOMParser();
+        const htmlDoc = parser.parseFromString(html, 'text/html');
+        const scriptsInHTML = htmlDoc.scripts;
+        let jsInScripts = '';
+
+        for (let i = 0; i < scriptsInHTML.length; i++) {
+            jsInScripts += scriptsInHTML[i].innerHTML;
+        }
+
+        const sanitizedHTMLInsideBody = DOMPurify.sanitize(html || '');
         const sanitizedCSS = DOMPurify.sanitize(css || '');
         const sanitizedJS = DOMPurify.sanitize(js || '');
+        const sanitizedJsInScripts = DOMPurify.sanitize(jsInScripts || '');
 
-        const _content = `
+        const content = `
                     <!DOCTYPE html>
                     <html>
                         <head>
+                        <title>Live Preview</title>
                         <style>${sanitizedCSS}</style>
                         </head>
                         <body>
-                        ${sanitizedHTML}
+                        ${sanitizedHTMLInsideBody}
                         <script>
-                            const originalConsoleLog = console.log;
-                            console.log = (...args) => {
-                            window.parent.postMessage({ type: 'console', message: args.join(' ') }, '*');
-                            originalConsoleLog.apply(console, args);
-                            };
+                            ['log', 'warn', 'error'].forEach((method) => {
+                                const originalConsoleMethod = console[method];
+                                console[method] = (...args) => {
+                                    const newArgs = args.map((arg) => {
+
+                                        if(typeof arg === 'object') {
+                                            return JSON.stringify(arg);
+                                        } else if(typeof arg === 'function') {
+                                            return arg.toString(); 
+                                        }
+
+                                        return arg;
+                                    });
+                                    window.parent.postMessage({ customType: 'CONSOLE', payload: {id: crypto.randomUUID() , message: newArgs.join(' '), logLevel: method} }, "${isProduction ? allowedOrigins[1] : allowedOrigins[0]}");
+                                    originalConsoleMethod.apply(console, args);
+                                };
+                            });
                             window.onerror = (msg) => {
-                            window.parent.postMessage({ type: 'error', message: msg }, '*');
+                                window.parent.postMessage({ customType: 'ERROR', payload: {id: crypto.randomUUID() , message: msg, logLevel: 'error'} }, "${isProduction ? allowedOrigins[1] : allowedOrigins[0]}");
                             };
                             try {
-                            ${sanitizedJS}
+                                ${sanitizedJS}
+                                ${sanitizedJsInScripts}
                             } catch (e) {
-                            window.parent.postMessage({ type: 'error', message: e.message }, '*');
+                                window.parent.postMessage({ customType: 'ERROR', payload: {id: crypto.randomUUID(), message: e.message, logLevel: 'error'} }, "${isProduction ? allowedOrigins[1] : allowedOrigins[0]}");
                             }
                         </script>
                         </body>
                     </html>
                     `;
 
+        dispatch(clearConsoleLogs());
+
         // Set srcdoc to avoid cross-origin issues
-        if (iframeRef.current) {
-            iframeRef.current.srcdoc = codeContent;
-        }
-    }, [html, css, js, codeContent]);
+        const timerId = setTimeout(() => {
+            requestAnimationFrame(() => {
+                iframe.srcdoc = content;
+            });
+
+            // Another way but Costly for each update
+            /* const blob = new Blob([content], { type: 'text/html' });
+            iframe.src = URL.createObjectURL(blob); */
+        }, 0);
+
+        return () => {
+            clearTimeout(timerId);
+        };
+    }, [html, css, js, dispatch]);
 
     useEffect(() => {
         function handleMessage(event) {
-            // Optional: Validate origin for security
-            const allowedOrigins = [
-                'http://localhost:5173',
-                'https://bytetogether.vercel.app',
-            ];
+            if (event.origin !== 'null' || !iframeRef.current?.srcdoc) return;
 
-            if (event.origin && !allowedOrigins.includes(event.origin)) {
+            if (
+                !event.data ||
+                typeof event.data !== 'object' ||
+                !event.data?.customType
+            )
                 return;
-            }
 
-            if (event.data.type === 'error') {
-                dispatch(
-                    addNotification({
-                        message: `JavaScript error: ${event.data.message}`,
-                        type: 'error',
-                        timeout: 4000,
-                    })
-                );
-                dispatch(setConsoleLogs(`Error: ${event.data.message}`));
-            } else if (event.data.type === 'console') {
-                dispatch(setConsoleLogs(event.data.message));
-            }
+            dispatch(setConsoleLogs(event.data.payload));
         }
         window.addEventListener('message', handleMessage);
         return () => window.removeEventListener('message', handleMessage);
     }, [dispatch]);
+
+    const consoleCSSClasses = {
+        warn: 'bg-yellow-400/50 dark:bg-yellow-400/30',
+        error: 'bg-[#c03e3a] dark:bg-[#9e3e3a] text-white',
+    };
+
+    function handleClearConsole() {
+        dispatch(clearConsoleLogs());
+    }
 
     return (
         <section
@@ -99,7 +139,7 @@ export default function PreviewPanel({
                 <iframe
                     ref={iframeRef}
                     title="Live Preview"
-                    sandbox="allow-scripts"
+                    sandbox="allow-scripts allow-forms"
                     className="h-screen w-full flex-1 rounded-md border-none md:h-full md:rounded-none"
                     aria-label="Live code preview"
                 />
@@ -113,26 +153,44 @@ export default function PreviewPanel({
                         role="separator"
                         aria-label="Resize console panel"
                     />
+                    <div className="h-0.25 w-full bg-gray-500 md:hidden"></div>
                     <div
-                        className="min-h-20 w-full overflow-auto bg-gray-100 p-2 md:h-[calc(var(--console-height))] md:min-h-10 dark:bg-[#222233]"
+                        className="relative min-h-20 w-full overflow-auto bg-gray-100 p-2 md:h-[calc(var(--console-height))] md:min-h-10 dark:bg-[#222233]"
                         aria-label="JavaScript console output"
                         aria-live="polite"
                     >
-                        <p className="text-sm font-bold">Console:</p>
-                        {consoleLogs.map((log, index) => (
-                            <p
-                                key={index} //TODO optimize this
-                                className="font-mono text-gray-800 dark:text-gray-200"
-                            >
-                                {log}
-                            </p>
-                        ))}
+                        <p className="pb-2 text-sm font-bold">Console:</p>
+                        <div className="flex flex-col gap-1">
+                            {consoleLogs.map((log) => {
+                                return (
+                                    <div
+                                        key={log.id}
+                                        className="flex flex-col gap-1"
+                                    >
+                                        <p
+                                            className={`rounded-md px-2 py-1 font-mono wrap-break-word whitespace-pre-wrap ${consoleCSSClasses[log.logLevel]}`}
+                                        >
+                                            {log.message}
+                                        </p>
+                                        <div className="h-0.25 w-full bg-gray-500"></div>
+                                    </div>
+                                );
+                            })}
+                        </div>
+                        <button
+                            className="absolute top-1.5 right-1 rounded-full p-1 hover:bg-gray-700 focus-visible:outline focus-visible:outline-offset-1 focus-visible:outline-blue-400"
+                            onClick={handleClearConsole}
+                            aria-label="Clear Console"
+                            title="Clear Console"
+                        >
+                            <Clear width={1} height={1} />
+                        </button>
                     </div>
                 </>
             )}
             <div className="flex w-full justify-center bg-inherit p-1">
                 <button
-                    className="cursor-pointer rounded bg-blue-600 px-2 py-1 text-white hover:bg-blue-700 md:w-full"
+                    className="w-1/2 cursor-pointer rounded bg-blue-600 px-2 py-1 text-white hover:bg-blue-700 focus:bg-blue-700 focus:outline focus:outline-offset-2 focus:outline-blue-500 md:w-full"
                     onClick={() =>
                         dispatch(setIsConsoleVisible(!isConsoleVisible))
                     }

--- a/client/src/components/svg/Clear.jsx
+++ b/client/src/components/svg/Clear.jsx
@@ -1,0 +1,25 @@
+import ClearIcon from '../../assets/icons/clear.svg?react';
+
+/**
+ * Clear Icon component for code formatting action.
+ * @param {Object} props - SVG props (e.g., width, height).
+ * @param {Object} props.width - Width of the svg.
+ * @param {Object} props.height - Height of the svg.
+ * @param {Object} props.className - CSS className for the svg.
+ * @returns {JSX.Element} The Clear icon.
+ */
+export default function Clear({
+    width = 1.5,
+    height = 1.5,
+    className = ``,
+    ...props
+}) {
+    return (
+        <ClearIcon
+            width={`${width}rem`}
+            height={`${height}rem`}
+            className={className}
+            {...props}
+        />
+    );
+}

--- a/client/src/conf/judge0Config.js
+++ b/client/src/conf/judge0Config.js
@@ -5,11 +5,22 @@ export const judge0Limits = {
     cpu_time_limit: '3.0', // 3s
     cpu_extra_time: '0.5', // Safety buffer
     wall_time_limit: '5.0', // Total runtime
-    memory_limit: 128000, // 128 MB
-    stack_limit: 64000, // 64 MB
+    memory_limit: 131072, // 128 MB
+    stack_limit: 65536, // 64 MB
     max_processes_and_or_threads: 32,
     enable_per_process_and_thread_time_limit: true,
     enable_per_process_and_thread_memory_limit: true,
     max_file_size: 4096, // 4 KB
-    enable_network: false, // Always keep false for safety
+    enable_network: false, // False for safety
+};
+
+/**
+ * Judge0 Verdicts
+ */
+export const judge0Verdicts = {
+    3: `✅ Successfully executed`,
+    5: `💥 Time Limit Exceeded`,
+    6: `❌ Compilation Error`,
+    7: `🛑 Runtime Error`,
+    13: `🚫 Memory Limit Exceeded`,
 };

--- a/client/src/conf/judge0Config.js
+++ b/client/src/conf/judge0Config.js
@@ -3,13 +3,13 @@
  */
 export const judge0Limits = {
     cpu_time_limit: '3.0', // 3s
-    cpu_extra_time: '0.5', // Safety buffer
-    wall_time_limit: '5.0', // Total runtime
-    memory_limit: 131072, // 128 MB
+    cpu_extra_time: '1.0', // Safety buffer
+    wall_time_limit: '6.0', // Total runtime
+    memory_limit: 262144, // 256 MB
     stack_limit: 65536, // 64 MB
-    max_processes_and_or_threads: 32,
-    enable_per_process_and_thread_time_limit: true,
-    enable_per_process_and_thread_memory_limit: true,
+    max_processes_and_or_threads: 64,
+    enable_per_process_and_thread_time_limit: false,
+    enable_per_process_and_thread_memory_limit: false,
     max_file_size: 4096, // 4 KB
     enable_network: false, // False for safety
 };

--- a/client/src/conf/judge0Limits.js
+++ b/client/src/conf/judge0Limits.js
@@ -1,0 +1,15 @@
+/**
+ * Custom Judge0 execution limits
+ */
+export const judge0Limits = {
+    cpu_time_limit: '3.0', // 3s
+    cpu_extra_time: '0.5', // Safety buffer
+    wall_time_limit: '5.0', // Total runtime
+    memory_limit: 128000, // 128 MB
+    stack_limit: 64000, // 64 MB
+    max_processes_and_or_threads: 32,
+    enable_per_process_and_thread_time_limit: true,
+    enable_per_process_and_thread_memory_limit: true,
+    max_file_size: 4096, // 4 KB
+    enable_network: false, // Always keep false for safety
+};

--- a/client/src/conf/languages.js
+++ b/client/src/conf/languages.js
@@ -36,7 +36,7 @@ export const judge0LanguagesIds = {
     c: 50,
     cpp: 54,
     java: 62,
-    js: 63,
-    py: 71,
-    ts: 74,
+    javascript: 63,
+    python: 71,
+    typescript: 74,
 };

--- a/client/src/conf/languages.js
+++ b/client/src/conf/languages.js
@@ -23,7 +23,7 @@ export const defaultsSnippets = {
     python: "print('Hello, World!')",
     cpp: '#include <iostream>\n\nint main() {\n    std::cout << "Hello, World!" << std::endl;\n    return 0;\n}',
     c: '#include <stdio.h>\n\nint main() {\n    printf("Hello, World!\\n");\n    return 0;\n}',
-    java: 'public class Main {\n\n    public static void main(String[] args) {\n        System.out.println("Hello, World!");\n    }\n\n}',
+    java: 'class Main {\n\n    public static void main(String[] args) {\n        System.out.println("Hello, World!");\n    }\n\n}',
     html: '<!DOCTYPE html>\n<html lang="en">\n<head>\n\t<meta charset="UTF-8">\n\t<meta name="viewport" content="width=device-width, initial-scale=1.0">\n\t<title>Hello</title>\n</head>\n<body>\n\t<h1>Hello, World!</h1>\n</body>\n</html>',
     css: 'body {\n    background-color: #ffffff;\n}',
 };

--- a/client/src/conf/modalConfig.jsx
+++ b/client/src/conf/modalConfig.jsx
@@ -276,7 +276,8 @@ export const modalConfig = {
                     For more shortcuts, press{' '}
                     <span className="rounded-md bg-gray-300 px-2 py-1 dark:bg-gray-600">
                         F1
-                    </span>
+                    </span>{' '}
+                    while in editor
                 </p>
             </div>
         ),

--- a/client/src/conf/modalConfig.jsx
+++ b/client/src/conf/modalConfig.jsx
@@ -273,8 +273,10 @@ export const modalConfig = {
                     </span>
                 </p>
                 <p className="text-xs text-pretty">
-                    Most of the VSCode shortcuts work in this editor. For more
-                    shortcuts, search VS Code shortcuts
+                    For more shortcuts, press{' '}
+                    <span className="rounded-md bg-gray-300 px-2 py-1 dark:bg-gray-600">
+                        F1
+                    </span>
                 </p>
             </div>
         ),

--- a/client/src/hooks/editor-layout-and-actions/usePanelsResize.js
+++ b/client/src/hooks/editor-layout-and-actions/usePanelsResize.js
@@ -5,8 +5,8 @@ import { useThrottle } from '../useThrottle';
 /**
  * Custom hook to enable panel resizing (horizontal and vertical) using mouse events.
  *
- * - Horizontal: Resizes between the CodeEditor and the Input/Output panel.
- * - Vertical: Resizes between InputPanel and OutputPanel within the right panel.
+ * - Horizontal: Resizes between the CodeEditor and the Input/Output or Preview panel.
+ * - Vertical: Resizes between InputPanel and OutputPanel or Preview Iframe and Console within the right panel.
  *
  * Attaches `mousemove` and `mouseup` event listeners to handle live resizing and cleanup on unmount.
  *
@@ -16,12 +16,16 @@ import { useThrottle } from '../useThrottle';
  * @param {React.RefObject<HTMLElement|null>} params.containerRef Ref to the container used for resizing calculations.
 
  * @param {React.RefObject<boolean>} params.isDraggingHorizontal Ref indicating horizontal drag state.
- * @param {React.RefObject<boolean>} params.isDraggingVertical Ref indicating vertical drag state.
- * @param {React.SetStateAction<Function>} params.setEditorWidth State setter to update editor width in percentage (20% - 80%).
- * @param {React.SetStateAction<Function>} params.setInputHeight State setter to update input panel height in percentage (20% - 80%).
- * @param {React.SetStateAction<Function>} params.setIsResizing State setter to toggle the resizing UI state.
- *
- */
+* @param {React.RefObject<boolean>} params.isDraggingVertical Ref indicating vertical drag state.
+* @param {React.SetStateAction<Function>} params.setEditorWidth State setter to update editor width in percentage (20% - 80%).
+* @param {React.SetStateAction<Function>} params.setInputHeight State setter to update input panel height in percentage (20% - 80%).
+* @param {React.SetStateAction<Function>} params.setIsResizing State setter to toggle the resizing UI state.
+* @param {number} params.consoleHeight - Console Height in percentage.
+* @param {React.SetStateAction<Function>} params.setConsoleHeight State setter for console height.
+* @param {React.ComponentState<boolean>} params.isPreviewVisible - Preview panel visibility.
+*
+* @param {React.RefObject<HTMLElement | null>} params.previewContainerRef Ref containing the preview panel wrapper DOM node.
+*/
 
 export function usePanelsResize({
     editorWidth,

--- a/client/src/hooks/editor-layout-and-actions/usePanelsResize.js
+++ b/client/src/hooks/editor-layout-and-actions/usePanelsResize.js
@@ -8,42 +8,51 @@ import { useEffect } from 'react';
  *
  * Attaches `mousemove` and `mouseup` event listeners to handle live resizing and cleanup on unmount.
  *
- * @param {Object} params Parameters for resizing logic.
- * @param {React.MutableRefObject<boolean>} params.isDraggingHorizontal Ref indicating horizontal drag state.
- * @param {React.MutableRefObject<boolean>} params.isDraggingVertical Ref indicating vertical drag state.
- * @param {React.MutableRefObject<HTMLElement|null>} params.containerRef Ref to the container used for resizing calculations.
+ * @param {Object} para
+ * @param {number} params.editorWidth - Editor width in percentage.
+ * @param {number} params.inputHeight - Input panel height in percentage.ms Parameters for resizing logic.
+ * @param {React.RefObject<HTMLElement|null>} params.containerRef Ref to the container used for resizing calculations.
+ * @param {React.RefObject<boolean>} params.isDraggingHorizontal Ref indicating horizontal drag state.
+ * @param {React.RefObject<boolean>} params.isDraggingVertical Ref indicating vertical drag state.
  * @param {React.SetStateAction<Function>} params.setEditorWidth State setter to update editor width in percentage (20% - 80%).
  * @param {React.SetStateAction<Function>} params.setInputHeight State setter to update input panel height in percentage (20% - 80%).
  * @param {React.SetStateAction<Function>} params.setIsResizing State setter to toggle the resizing UI state.
- *
+ * @param {number} params.consoleHeight - Console height in pixels (for PreviewPanel).
+ * @param {React.SetStateAction<Function>} params.setConsoleHeight - Set console height.
+ * @param {boolean} params.showPreview - Whether PreviewPanel is visible.
  */
 
 export function usePanelsResize({
     editorWidth,
     inputHeight,
-    isDraggingHorizontal,
     containerRef,
-    setEditorWidth,
-    setIsResizing,
+    isDraggingHorizontal,
     isDraggingVertical,
+    setEditorWidth,
     setInputHeight,
+    setIsResizing,
+    consoleHeight,
+    setConsoleHeight,
+    showPreview,
 }) {
     /**
      * Horizontal resize (CodeEditor vs Right Panel)
      */
-    function handleHorizontalMouseDown() {
+    function handleHorizontalMouseDown(event) {
         if (window.innerWidth < 768) return; // Disable resizing on mobile
         isDraggingHorizontal.current = true;
         setIsResizing(true);
+        event.preventDefault();
     }
 
     /**
      * Vertical resize (OutputPanel vs InputPanel)
      */
-    function handleVerticalMouseDown() {
+    function handleVerticalMouseDown(event) {
         if (window.innerWidth < 768) return; // Disable resizing on mobile
         isDraggingVertical.current = true;
         setIsResizing(true);
+        event.preventDefault();
     }
 
     // Update container styles dynamically
@@ -57,8 +66,12 @@ export function usePanelsResize({
                 '--input-height',
                 `${inputHeight}%`
             );
+            containerRef.current.style.setProperty(
+                '--console-height',
+                `${consoleHeight}px`
+            );
         }
-    }, [containerRef, editorWidth, inputHeight]);
+    }, [consoleHeight, containerRef, editorWidth, inputHeight]);
 
     // Add global event listeners for dragging
     useEffect(() => {
@@ -78,12 +91,17 @@ export function usePanelsResize({
 
         function handleVerticalMouseMove(e) {
             if (isDraggingVertical.current && containerRef.current) {
-                const containerHeight = containerRef.current.offsetHeight;
-                const newY =
-                    e.clientY -
-                    containerRef.current.getBoundingClientRect().top;
-                const newHeight = (newY / containerHeight) * 100;
-                setInputHeight(Math.max(20, Math.min(80, newHeight))); // Min 20%, Max 80%
+                const containerRect =
+                    containerRef.current.getBoundingClientRect();
+                const containerHeight = containerRect.height;
+                const newY = e.clientY - containerRect.top;
+                if (showPreview) {
+                    const newHeight = Math.max(100, Math.min(400, newY));
+                    setConsoleHeight(newHeight);
+                } else {
+                    const newHeight = (newY / containerHeight) * 100;
+                    setInputHeight(Math.max(20, Math.min(80, newHeight)));
+                }
             }
         }
 
@@ -98,20 +116,57 @@ export function usePanelsResize({
         window.addEventListener('mousemove', handleVerticalMouseMove);
         window.addEventListener('mouseup', handleVerticalMouseUp);
 
+        // Touch events for mobile
+        /* function handleTouchMove(e) {
+            if (isDraggingHorizontal.current && containerRef.current) {
+                const containerWidth = containerRef.current.offsetWidth;
+                const newX = e.touches[0].clientX;
+                const newWidth = (newX / containerWidth) * 100;
+                setEditorWidth(Math.max(20, Math.min(80, newWidth)));
+            } else if (isDraggingVertical.current && containerRef.current) {
+                const containerRect =
+                    containerRef.current.getBoundingClientRect();
+                const containerHeight = containerRect.height;
+                const newY = e.touches[0].clientY - containerRect.top;
+                if (showPreview) {
+                    const newHeight = Math.max(100, Math.min(400, newY));
+                    setConsoleHeight(newHeight);
+                } else {
+                    const newHeight = (newY / containerHeight) * 100;
+                    setInputHeight(Math.max(20, Math.min(80, newHeight)));
+                }
+            }
+        }
+
+        function handleTouchEnd() {
+            isDraggingHorizontal.current = false;
+            isDraggingVertical.current = false;
+            setIsResizing(false);
+        }
+
+        window.addEventListener('touchmove', handleTouchMove, {
+            passive: false,
+        });
+        window.addEventListener('touchend', handleTouchEnd); */
+
         // Cleanup
         return () => {
             window.removeEventListener('mousemove', handleHorizontalMouseMove);
             window.removeEventListener('mouseup', handleHorizontalMouseUp);
             window.removeEventListener('mousemove', handleVerticalMouseMove);
             window.removeEventListener('mouseup', handleVerticalMouseUp);
+            // window.removeEventListener('touchmove', handleTouchMove);
+            // window.removeEventListener('touchend', handleTouchEnd);
         };
     }, [
         containerRef,
         isDraggingHorizontal,
         isDraggingVertical,
+        setConsoleHeight,
         setEditorWidth,
         setInputHeight,
         setIsResizing,
+        showPreview,
     ]);
 
     return { handleHorizontalMouseDown, handleVerticalMouseDown };

--- a/client/src/hooks/editor-layout-and-actions/usePanelsResize.js
+++ b/client/src/hooks/editor-layout-and-actions/usePanelsResize.js
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useCallback, useEffect } from 'react';
 
 /**
  * Custom hook to enable panel resizing (horizontal and vertical) using mouse events.
@@ -8,18 +8,17 @@ import { useEffect } from 'react';
  *
  * Attaches `mousemove` and `mouseup` event listeners to handle live resizing and cleanup on unmount.
  *
- * @param {Object} para
+ * @param {Object} params Parameters for resizing logic.
  * @param {number} params.editorWidth - Editor width in percentage.
  * @param {number} params.inputHeight - Input panel height in percentage.ms Parameters for resizing logic.
  * @param {React.RefObject<HTMLElement|null>} params.containerRef Ref to the container used for resizing calculations.
+
  * @param {React.RefObject<boolean>} params.isDraggingHorizontal Ref indicating horizontal drag state.
  * @param {React.RefObject<boolean>} params.isDraggingVertical Ref indicating vertical drag state.
  * @param {React.SetStateAction<Function>} params.setEditorWidth State setter to update editor width in percentage (20% - 80%).
  * @param {React.SetStateAction<Function>} params.setInputHeight State setter to update input panel height in percentage (20% - 80%).
  * @param {React.SetStateAction<Function>} params.setIsResizing State setter to toggle the resizing UI state.
- * @param {number} params.consoleHeight - Console height in pixels (for PreviewPanel).
- * @param {React.SetStateAction<Function>} params.setConsoleHeight - Set console height.
- * @param {boolean} params.showPreview - Whether PreviewPanel is visible.
+ *
  */
 
 export function usePanelsResize({
@@ -31,29 +30,26 @@ export function usePanelsResize({
     setEditorWidth,
     setInputHeight,
     setIsResizing,
-    consoleHeight,
-    setConsoleHeight,
-    showPreview,
 }) {
     /**
      * Horizontal resize (CodeEditor vs Right Panel)
      */
-    function handleHorizontalMouseDown(event) {
+    const handleHorizontalMouseDown = useCallback(() => {
         if (window.innerWidth < 768) return; // Disable resizing on mobile
+
         isDraggingHorizontal.current = true;
         setIsResizing(true);
-        event.preventDefault();
-    }
+    }, [isDraggingHorizontal, setIsResizing]);
 
     /**
      * Vertical resize (OutputPanel vs InputPanel)
      */
-    function handleVerticalMouseDown(event) {
+    const handleVerticalMouseDown = useCallback(() => {
         if (window.innerWidth < 768) return; // Disable resizing on mobile
+
         isDraggingVertical.current = true;
         setIsResizing(true);
-        event.preventDefault();
-    }
+    }, [isDraggingVertical, setIsResizing]);
 
     // Update container styles dynamically
     useEffect(() => {
@@ -66,22 +62,21 @@ export function usePanelsResize({
                 '--input-height',
                 `${inputHeight}%`
             );
-            containerRef.current.style.setProperty(
-                '--console-height',
-                `${consoleHeight}px`
-            );
         }
-    }, [consoleHeight, containerRef, editorWidth, inputHeight]);
+    }, [containerRef, editorWidth, inputHeight]);
 
     // Add global event listeners for dragging
     useEffect(() => {
         function handleHorizontalMouseMove(event) {
-            if (isDraggingHorizontal.current && containerRef.current) {
-                const containerWidth = containerRef.current.offsetWidth;
-                const newX = event.clientX;
-                const newWidth = (newX / containerWidth) * 100;
-                setEditorWidth(Math.max(20, Math.min(80, newWidth))); // Min 20%, Max 80%
+            if (!isDraggingHorizontal.current || !containerRef.current) {
+                return;
             }
+
+            const containerWidth = containerRef.current.offsetWidth;
+            const newX = event.clientX;
+            const newWidth = (newX / containerWidth) * 100;
+
+            setEditorWidth(Math.max(20, Math.min(80, newWidth))); // Min 20%, Max 80%
         }
 
         function handleHorizontalMouseUp() {
@@ -90,19 +85,16 @@ export function usePanelsResize({
         }
 
         function handleVerticalMouseMove(e) {
-            if (isDraggingVertical.current && containerRef.current) {
-                const containerRect =
-                    containerRef.current.getBoundingClientRect();
-                const containerHeight = containerRect.height;
-                const newY = e.clientY - containerRect.top;
-                if (showPreview) {
-                    const newHeight = Math.max(100, Math.min(400, newY));
-                    setConsoleHeight(newHeight);
-                } else {
-                    const newHeight = (newY / containerHeight) * 100;
-                    setInputHeight(Math.max(20, Math.min(80, newHeight)));
-                }
+            if (!isDraggingVertical.current || !containerRef.current) {
+                return;
             }
+
+            const containerHeight = containerRef.current.offsetHeight;
+            const newY =
+                e.clientY - containerRef.current.getBoundingClientRect().top;
+            const newHeight = (newY / containerHeight) * 100;
+
+            setInputHeight(Math.max(20, Math.min(80, newHeight))); // Min 20%, Max 80%
         }
 
         function handleVerticalMouseUp() {
@@ -111,62 +103,51 @@ export function usePanelsResize({
         }
 
         // Listeners
-        window.addEventListener('mousemove', handleHorizontalMouseMove);
-        window.addEventListener('mouseup', handleHorizontalMouseUp);
-        window.addEventListener('mousemove', handleVerticalMouseMove);
-        window.addEventListener('mouseup', handleVerticalMouseUp);
+        containerRef.current?.addEventListener(
+            'mousemove',
+            handleHorizontalMouseMove
+        );
+        containerRef.current?.addEventListener(
+            'mouseup',
+            handleHorizontalMouseUp
+        );
+        containerRef.current?.addEventListener(
+            'mousemove',
+            handleVerticalMouseMove
+        );
+        containerRef.current?.addEventListener(
+            'mouseup',
+            handleVerticalMouseUp
+        );
 
-        // Touch events for mobile
-        /* function handleTouchMove(e) {
-            if (isDraggingHorizontal.current && containerRef.current) {
-                const containerWidth = containerRef.current.offsetWidth;
-                const newX = e.touches[0].clientX;
-                const newWidth = (newX / containerWidth) * 100;
-                setEditorWidth(Math.max(20, Math.min(80, newWidth)));
-            } else if (isDraggingVertical.current && containerRef.current) {
-                const containerRect =
-                    containerRef.current.getBoundingClientRect();
-                const containerHeight = containerRect.height;
-                const newY = e.touches[0].clientY - containerRect.top;
-                if (showPreview) {
-                    const newHeight = Math.max(100, Math.min(400, newY));
-                    setConsoleHeight(newHeight);
-                } else {
-                    const newHeight = (newY / containerHeight) * 100;
-                    setInputHeight(Math.max(20, Math.min(80, newHeight)));
-                }
-            }
-        }
-
-        function handleTouchEnd() {
-            isDraggingHorizontal.current = false;
-            isDraggingVertical.current = false;
-            setIsResizing(false);
-        }
-
-        window.addEventListener('touchmove', handleTouchMove, {
-            passive: false,
-        });
-        window.addEventListener('touchend', handleTouchEnd); */
+        const containerRefCopy = containerRef.current;
 
         // Cleanup
         return () => {
-            window.removeEventListener('mousemove', handleHorizontalMouseMove);
-            window.removeEventListener('mouseup', handleHorizontalMouseUp);
-            window.removeEventListener('mousemove', handleVerticalMouseMove);
-            window.removeEventListener('mouseup', handleVerticalMouseUp);
-            // window.removeEventListener('touchmove', handleTouchMove);
-            // window.removeEventListener('touchend', handleTouchEnd);
+            containerRefCopy?.removeEventListener(
+                'mousemove',
+                handleHorizontalMouseMove
+            );
+            containerRefCopy?.removeEventListener(
+                'mouseup',
+                handleHorizontalMouseUp
+            );
+            containerRefCopy?.removeEventListener(
+                'mousemove',
+                handleVerticalMouseMove
+            );
+            containerRefCopy?.removeEventListener(
+                'mouseup',
+                handleVerticalMouseUp
+            );
         };
     }, [
         containerRef,
         isDraggingHorizontal,
         isDraggingVertical,
-        setConsoleHeight,
         setEditorWidth,
         setInputHeight,
         setIsResizing,
-        showPreview,
     ]);
 
     return { handleHorizontalMouseDown, handleVerticalMouseDown };

--- a/client/src/hooks/useThrottle.js
+++ b/client/src/hooks/useThrottle.js
@@ -1,0 +1,65 @@
+import { useCallback, useEffect, useRef } from 'react';
+
+/**
+ * Custom hook that throttles a callback function to execute only once within an interval, ignoring subsequent calls within that interval.
+ * @param {function} callback - The callback function to execute once within the provided interval
+ * @param {number} interval - The interval in milliseconds during which the callback is to be executed once
+ * @param {{ leading?: boolean, trailing?: boolean }} options - Config for leading/trailing execution of callback
+ * @returns {function} A memoized throttled version of the callback
+ */
+export function useThrottle(callback, interval, options = {}) {
+    const { leading = true, trailing = true } = options;
+
+    const lastCallTimeRef = useRef(0);
+    const savedCallbackRef = useRef(callback);
+    const timeoutRef = useRef(null);
+    const savedArgsRef = useRef([]);
+
+    // Always keep the latest version of the callback
+    useEffect(() => {
+        savedCallbackRef.current = callback;
+    }, [callback]);
+
+    // Clean up timeout on unmount
+    useEffect(() => {
+        return () => clearTimeout(timeoutRef.current);
+    }, []);
+
+    return useCallback(
+        (...args) => {
+            const now = Date.now();
+
+            if (!leading && !trailing) {
+                console.warn(
+                    'useThrottle: Both leading and trailing are false. Callback will never be called.'
+                );
+            }
+
+            const callNow = leading && lastCallTimeRef.current === 0;
+            const timeSinceLastCall = now - lastCallTimeRef.current;
+            const shouldCall = timeSinceLastCall >= interval;
+
+            if (callNow || shouldCall) {
+                if (timeoutRef.current) {
+                    clearTimeout(timeoutRef.current);
+                    timeoutRef.current = null;
+                }
+                savedCallbackRef.current(...args);
+                lastCallTimeRef.current = now;
+            } else if (trailing) {
+                savedArgsRef.current = args;
+
+                if (!timeoutRef.current) {
+                    const remaining = interval - timeSinceLastCall;
+
+                    timeoutRef.current = setTimeout(() => {
+                        savedCallbackRef.current(...savedArgsRef.current);
+                        lastCallTimeRef.current = Date.now();
+                        timeoutRef.current = null;
+                    }, remaining);
+                }
+            }
+        },
+        [interval, leading, trailing]
+    );
+}

--- a/client/src/hooks/yjs-real-time-sync/useRealTimeSync.js
+++ b/client/src/hooks/yjs-real-time-sync/useRealTimeSync.js
@@ -136,8 +136,11 @@ export function useRealTimeSync({
 
             // Handle server messages
             function handleMessage(event) {
-                if (event.data instanceof ArrayBuffer) {
-                    return; // Skip Yjs protocol messages
+                if (
+                    event.data instanceof ArrayBuffer ||
+                    ArrayBuffer.isView(event.data)
+                ) {
+                    return; // Skip Yjs protocol sync messages. Skip parsing as JSON
                 }
                 try {
                     const message = JSON.parse(event.data);

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -8,6 +8,7 @@ body,
     min-height: 100vh;
     height: 100%;
     width: 100%;
+    color-scheme: light, dark;
 }
 
 /* Disable text selection while resizing panels */

--- a/client/src/store/index.js
+++ b/client/src/store/index.js
@@ -65,6 +65,25 @@ const userPersistConfig = {
     whitelist: ['profile', 'preferences'], // Persist only profile and preferences
 };
 
+/**
+ * Persistence configuration for the execution slice.
+ * @type {Object}
+ */
+const executionPersistConfig = {
+    key: 'execution',
+    storage,
+    whitelist: ['executionMode'], // Persist only exeuctionMode
+};
+
+/**
+ * Persistence configuration for the preview slice.
+ * @type {Object}
+ */
+const previewPersistConfig = {
+    key: 'preview',
+    storage,
+};
+
 // Combined reducers
 const rootReducer = combineReducers({
     auth: persistReducer(authPersistConfig, authReducer),
@@ -72,8 +91,8 @@ const rootReducer = combineReducers({
     editor: persistReducer(editorPersistConfig, editorReducer),
     files: persistReducer(filesPersistConfig, filesReducer),
     user: persistReducer(userPersistConfig, userReducer),
-    execution: executionReducer,
-    preview: previewReducer,
+    execution: persistReducer(executionPersistConfig, executionReducer),
+    preview: persistReducer(previewPersistConfig, previewReducer),
 });
 
 // Redux Store config

--- a/client/src/store/index.js
+++ b/client/src/store/index.js
@@ -8,6 +8,7 @@ import editorReducer from './slices/editorSlice';
 import filesReducer from './slices/filesSlice';
 import userReducer from './slices/userSlice';
 import executionReducer from './slices/executionSlice';
+import previewReducer from './slices/previewSlice';
 
 /**
  * Persistence configuration for the auth slice.
@@ -72,6 +73,7 @@ const rootReducer = combineReducers({
     files: persistReducer(filesPersistConfig, filesReducer),
     user: persistReducer(userPersistConfig, userReducer),
     execution: executionReducer,
+    preview: previewReducer,
 });
 
 // Redux Store config

--- a/client/src/store/slices/executionSlice.js
+++ b/client/src/store/slices/executionSlice.js
@@ -9,6 +9,9 @@ const executionSlice = createSlice({
         output: '',
         input: '',
         error: '',
+        status: null,
+        time: '',
+        memory: null,
         isRunning: false,
         executionMode: 'judge0', // or "preview"
     },
@@ -43,6 +46,33 @@ const executionSlice = createSlice({
             state.output = '';
         },
         /**
+         * Sets the status after execution.
+         * @param {Object} state
+         * @param {Object} action
+         * @param {string} action.payload
+         */
+        setStatus(state, action) {
+            state.status = action.payload;
+        },
+        /**
+         * Sets the time taken to execute.
+         * @param {Object} state
+         * @param {Object} action
+         * @param {string} action.payload
+         */
+        setTime(state, action) {
+            state.time = action.payload;
+        },
+        /**
+         * Sets the status after execution.
+         * @param {Object} state
+         * @param {Object} action
+         * @param {string} action.payload
+         */
+        setMemory(state, action) {
+            state.memory = action.payload;
+        },
+        /**
          * Sets the running state.
          * @param {Object} state
          * @param {Object} action
@@ -60,9 +90,30 @@ const executionSlice = createSlice({
         setExecutionMode(state, action) {
             state.executionMode = action.payload;
         },
+        /**
+         * Clears Judge0 states.
+         * @param {Object} state
+         */
+        clearJudge0States(state) {
+            state.output = '';
+            state.input = '';
+            state.error = '';
+            state.status = null;
+            state.time = '';
+            state.memory = null;
+        },
     },
 });
 
-export const { setOutput, setError, setIsRunning, setExecutionMode, setInput } =
-    executionSlice.actions;
+export const {
+    setOutput,
+    setError,
+    setIsRunning,
+    setExecutionMode,
+    setInput,
+    setMemory,
+    setStatus,
+    setTime,
+    clearJudge0States,
+} = executionSlice.actions;
 export default executionSlice.reducer;

--- a/client/src/store/slices/executionSlice.js
+++ b/client/src/store/slices/executionSlice.js
@@ -9,6 +9,7 @@ const executionSlice = createSlice({
         output: '',
         error: '',
         isRunning: false,
+        executionMode: 'judge0', // or "preview"
     },
     reducers: {
         /**
@@ -40,8 +41,18 @@ const executionSlice = createSlice({
         setIsRunning(state, action) {
             state.isRunning = action.payload;
         },
+        /**
+         * Sets the execution mode state.
+         * @param {Object} state
+         * @param {Object} action
+         * @param {boolean} action.payload
+         */
+        setExecutionMode(state, action) {
+            state.executionMode = action.payload;
+        },
     },
 });
 
-export const { setOutput, setError, setIsRunning } = executionSlice.actions;
+export const { setOutput, setError, setIsRunning, setExecutionMode } =
+    executionSlice.actions;
 export default executionSlice.reducer;

--- a/client/src/store/slices/executionSlice.js
+++ b/client/src/store/slices/executionSlice.js
@@ -7,6 +7,7 @@ const executionSlice = createSlice({
     name: 'execution',
     initialState: {
         output: '',
+        input: '',
         error: '',
         isRunning: false,
         executionMode: 'judge0', // or "preview"
@@ -21,6 +22,15 @@ const executionSlice = createSlice({
         setOutput(state, action) {
             state.output = action.payload;
             state.error = '';
+        },
+        /**
+         * Sets the execution input.
+         * @param {Object} state
+         * @param {Object} action
+         * @param {string} action.payload
+         */
+        setInput(state, action) {
+            state.input = action.payload;
         },
         /**
          * Sets the execution error.
@@ -53,6 +63,6 @@ const executionSlice = createSlice({
     },
 });
 
-export const { setOutput, setError, setIsRunning, setExecutionMode } =
+export const { setOutput, setError, setIsRunning, setExecutionMode, setInput } =
     executionSlice.actions;
 export default executionSlice.reducer;

--- a/client/src/store/slices/previewSlice.js
+++ b/client/src/store/slices/previewSlice.js
@@ -1,0 +1,103 @@
+import { createSlice } from '@reduxjs/toolkit';
+
+/**
+ * Redux slice for managing code preview state.
+ */
+const previewSlice = createSlice({
+    name: 'preview',
+    initialState: {
+        isPreviewVisible: false,
+        html: '',
+        css: '',
+        js: '',
+        consoleLogs: [],
+        isConsoleVisible: false,
+        error: null,
+    },
+    reducers: {
+        /**
+         * Sets the visibility of preview panel.
+         * @param {Object} state
+         * @param {Object} action
+         * @param {string} action.payload
+         */
+        setIsPreviewVisible(state, action) {
+            state.isPreviewVisible = action.payload;
+        },
+        /**
+         * Sets the html output.
+         * @param {Object} state
+         * @param {Object} action
+         * @param {string} action.payload
+         */
+        setHtml(state, action) {
+            state.html = action.payload;
+        },
+        /**
+         * Sets the css output.
+         * @param {Object} state
+         * @param {Object} action
+         * @param {string} action.payload
+         */
+        setCss(state, action) {
+            state.css = action.payload;
+        },
+        /**
+         * Sets the js output.
+         * @param {Object} state
+         * @param {Object} action
+         * @param {string} action.payload
+         */
+        setJs(state, action) {
+            state.js = action.payload;
+        },
+        /**
+         * Sets the visibility of console in preview panel.
+         * @param {Object} state
+         * @param {Object} action
+         * @param {string} action.payload
+         */
+        setIsConsoleVisible(state, action) {
+            state.isConsoleVisible = action.payload;
+        },
+        /**
+         * Sets the console logs for the iframe doc.
+         * @param {Object} state
+         * @param {Object} action
+         * @param {string} action.payload
+         */
+        setConsoleLogs(state, action) {
+            state.consoleLogs.push(action.payload);
+        },
+        /**
+         * Clears the console logs for the iframe doc.
+         * @param {Object} state
+         * @param {Object} action
+         * @param {string} action.payload
+         */
+        clearConsoleLogs(state) {
+            state.consoleLogs = [];
+        },
+        /**
+         * Sets the error state for preview mode.
+         * @param {Object} state
+         * @param {Object} action
+         * @param {string} action.payload
+         */
+        setError(state, action) {
+            state.error = action.payload;
+        },
+    },
+});
+
+export const {
+    setHtml,
+    setCss,
+    setJs,
+    setConsoleLogs,
+    clearConsoleLogs,
+    setError,
+    setIsConsoleVisible,
+    setIsPreviewVisible,
+} = previewSlice.actions;
+export default previewSlice.reducer;

--- a/client/src/store/slices/previewSlice.js
+++ b/client/src/store/slices/previewSlice.js
@@ -67,7 +67,11 @@ const previewSlice = createSlice({
          * @param {string} action.payload
          */
         setConsoleLogs(state, action) {
-            state.consoleLogs.push(action.payload);
+            if (
+                !state.consoleLogs.some((log) => log.id === action.payload?.id)
+            ) {
+                state.consoleLogs.push(action.payload);
+            }
         },
         /**
          * Clears the console logs for the iframe doc.

--- a/client/src/utils/base64.js
+++ b/client/src/utils/base64.js
@@ -1,0 +1,43 @@
+/**
+ * Converts a Uint8Array to a Base64-encoded string.
+ * Safe for all UTF-8 characters (emojis, symbols, etc.)
+ * @param {Uint8Array} bytes Stream of Uint8Array bytes
+ * @returns {string} A Base64-encoded string
+ */
+function bytesToBase64(bytes) {
+    const binString = Array.from(bytes, (byte) =>
+        String.fromCodePoint(byte)
+    ).join('');
+    return btoa(binString);
+}
+
+/**
+ * Converts a Base64-encoded string to a Uint8Array.
+ * @param {string} base64 A Base64-encoded string
+ * @returns Stream of Uint8Array bytes
+ */
+function base64ToBytes(base64) {
+    const binString = atob(base64);
+    return Uint8Array.from(binString, (char) => char.codePointAt(0));
+}
+
+/**
+ * Encodes a raw UTF-8 string into a Base64 string.
+ * Safe for all languages, symbols, emojis, etc.
+ * @param {string} str UTF-8 string
+ * @returns {string} Base64-encoded string
+ */
+export function encodeToBase64(str) {
+    const utf8Bytes = new TextEncoder().encode(str);
+    return bytesToBase64(utf8Bytes);
+}
+
+/**
+ * Decodes a Base64 string back into its original UTF-8 string.
+ * @param {string} base64 Base64-encoded string
+ * @returns {string} UTF-8 string
+ */
+export function decodeFromBase64(base64) {
+    const bytes = base64ToBytes(base64);
+    return new TextDecoder().decode(bytes);
+}

--- a/client/src/utils/getJudge0LanguageId.js
+++ b/client/src/utils/getJudge0LanguageId.js
@@ -5,6 +5,6 @@ import { judge0LanguagesIds } from '../conf/languages';
  * @param {string} languageExtension - The programming language extension.
  * @returns {number} Judge0 language id or id of plain text if undefined.
  */
-export function getJudge0LanguageId(languageExtension) {
-    return judge0LanguagesIds[languageExtension] || 43;
+export function getJudge0LanguageId(language) {
+    return judge0LanguagesIds[language] || 43;
 }

--- a/server/index.js
+++ b/server/index.js
@@ -61,7 +61,7 @@ const httpServer = createServer(app);
 // Cors package middleware
 app.use(cors({ origin: ALLOWED_ORIGINS }));
 app.use(express.json());
-app.use('/api', judge0Routes); // Mount Judge0 routes
+app.use('/', judge0Routes); // Mount Judge0 routes
 
 // WebSocket server instance.
 // Attach it to the HTTP server and keep noServer to handle custom ws upgrade logic

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -156,9 +156,9 @@
             }
         },
         "node_modules/@eslint/plugin-kit": {
-            "version": "0.3.3",
-            "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.3.tgz",
-            "integrity": "sha512-1+WqvgNMhmlAambTvT3KPtCl/Ibr68VldY2XY40SL1CE0ZXiakFR/cbTspaF5HsnpDMvcYYoJHfl4980NBjGag==",
+            "version": "0.3.4",
+            "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.4.tgz",
+            "integrity": "sha512-Ul5l+lHEcw3L5+k8POx6r74mxEYKG5kOb6Xpy2gCRW6zweT6TEhAf8vhxGgjhqrd/VO/Dirhsb+1hNpD1ue9hw==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {

--- a/server/routes/judge0.js
+++ b/server/routes/judge0.js
@@ -18,8 +18,6 @@ const JUDGE0_API_KEY = process.env.JUDGE0_API_KEY;
  */
 router.post('/submissions', async (req, res) => {
     try {
-        console.log(req.body.source_code, typeof req.body.source_code);
-
         const response = await axios.post(
             `${JUDGE0_URL}/submissions${req.query.base64_encoded ? '?base64_encoded=true' : ''}&wait=false&fields=*`,
             req.body,

--- a/server/routes/judge0.js
+++ b/server/routes/judge0.js
@@ -2,6 +2,11 @@ import { Buffer } from 'node:buffer';
 import express from 'express';
 import axios from 'axios';
 
+if (process.env.NODE_ENV !== 'production') {
+    const dotenv = await import('dotenv');
+    dotenv.config();
+}
+
 const router = express.Router();
 const JUDGE0_URL = process.env.JUDGE0_URL || 'https://judge0-ce.p.rapidapi.com';
 const JUDGE0_API_KEY = process.env.JUDGE0_API_KEY;
@@ -13,24 +18,16 @@ const JUDGE0_API_KEY = process.env.JUDGE0_API_KEY;
  */
 router.post('/submissions', async (req, res) => {
     try {
-        const body = req.body;
-        if (body.source_code) {
-            body.source_code = Buffer.from(body.source_code, 'base64').toString(
-                'base64'
-            );
-        }
-        if (body.stdin) {
-            body.stdin = Buffer.from(body.stdin, 'base64').toString('base64');
-        }
+        console.log(req.body.source_code, typeof req.body.source_code);
 
         const response = await axios.post(
-            `${JUDGE0_URL}/submissions${req.query.base64_encoded ? '?base64_encoded=true' : ''}`,
+            `${JUDGE0_URL}/submissions${req.query.base64_encoded ? '?base64_encoded=true' : ''}&wait=false&fields=*`,
             req.body,
             {
                 headers: {
                     'content-type': 'application/json',
                     'x-rapidapi-key': JUDGE0_API_KEY,
-                    'X-rapidapi-host': 'judge0-ce.p.rapidapi.com',
+                    'x-rapidapi-host': 'judge0-ce.p.rapidapi.com',
                 },
             }
         );
@@ -52,7 +49,7 @@ router.post('/submissions', async (req, res) => {
                 headers: {
                     'content-type': 'application/json',
                     'x-rapidapi-key': JUDGE0_API_KEY,
-                    'X-rapidapi-host': 'judge0-ce.p.rapidapi.com',
+                    'x-rapidapi-host': 'judge0-ce.p.rapidapi.com',
                 },
                 body: JSON.stringify(req.body),
             }

--- a/server/routes/judge0.js
+++ b/server/routes/judge0.js
@@ -1,0 +1,130 @@
+import { Buffer } from 'node:buffer';
+import express from 'express';
+import axios from 'axios';
+
+const router = express.Router();
+const JUDGE0_URL = process.env.JUDGE0_URL || 'https://judge0-ce.p.rapidapi.com';
+const JUDGE0_API_KEY = process.env.JUDGE0_API_KEY;
+
+/**
+ * POST /api/submissions - Create a Judge0 submission.
+ * @param {Object} req - Express request object.
+ * @param {Object} res - Express response object.
+ */
+router.post('/submissions', async (req, res) => {
+    try {
+        const body = req.body;
+        if (body.source_code) {
+            body.source_code = Buffer.from(body.source_code, 'base64').toString(
+                'base64'
+            );
+        }
+        if (body.stdin) {
+            body.stdin = Buffer.from(body.stdin, 'base64').toString('base64');
+        }
+
+        const response = await axios.post(
+            `${JUDGE0_URL}/submissions${req.query.base64_encoded ? '?base64_encoded=true' : ''}`,
+            req.body,
+            {
+                headers: {
+                    'content-type': 'application/json',
+                    'x-rapidapi-key': JUDGE0_API_KEY,
+                    'X-rapidapi-host': 'judge0-ce.p.rapidapi.com',
+                },
+            }
+        );
+        return res.status(response.status).json(response.data);
+    } catch (error) {
+        return res.status(error.response?.status || 500).json({
+            error: error.message,
+        });
+    }
+});
+
+// fetch variant
+/* router.post('/submissions', async (req, res) => {
+    try {
+        const response = await fetch(
+            `${JUDGE0_URL}/submissions${req.query.base64_encoded ? '?base64_encoded=true' : ''}&wait=false&fields=*`,
+            {
+                method: 'POST',
+                headers: {
+                    'content-type': 'application/json',
+                    'x-rapidapi-key': JUDGE0_API_KEY,
+                    'X-rapidapi-host': 'judge0-ce.p.rapidapi.com',
+                },
+                body: JSON.stringify(req.body),
+            }
+        );
+
+        if (!response.ok) {
+            throw new Error(
+                `Judge0 API error: ${response.status} - ${response.statusText}`
+            );
+        }
+
+        const data = await response.json();
+        return res.status(response.status).json(data);
+    } catch (error) {
+        return res.status(error.response?.status || 500).json({
+            error: error.message,
+        });
+    }
+}); */
+
+/**
+ * GET /api/submissions/:token - Poll Judge0 submission result.
+ * @param {Object} req - Express request object.
+ * @param {Object} res - Express response object.
+ */
+router.get('/submissions/:token', async (req, res) => {
+    const { token } = req.params;
+    try {
+        const response = await axios.get(
+            `${JUDGE0_URL}/submissions/${token}${req.query.base64_encoded ? '?base64_encoded=true' : ''}&fields=*`,
+            {
+                headers: {
+                    'x-rapidapi-key': JUDGE0_API_KEY,
+                    'x-rapidapi-host': 'judge0-ce.p.rapidapi.com',
+                },
+            }
+        );
+        return res.status(response.status).json(response.data);
+    } catch (error) {
+        return res.status(error.response?.status || 500).json({
+            error: error.message,
+        });
+    }
+});
+
+// fetch variant
+/* router.get('/submissions/:token', async (req, res) => {
+    const { token } = req.params;
+    try {
+        const response = await fetch(
+            `${JUDGE0_URL}/submissions/${token}${req.query.base64_encoded ? '?base64_encoded=true' : ''}&fields=*`,
+            {
+                headers: {
+                    'x-rapidapi-key': JUDGE0_API_KEY,
+                    'x-rapidapi-host': 'judge0-ce.p.rapidapi.com',
+                },
+            }
+        );
+
+        if (!response.ok) {
+            throw new Error(
+                `Judge0 API error: ${response.status} - ${response.statusText}`
+            );
+        }
+
+        const data = await response.json();
+        return res.status(response.status).json(data);
+    } catch (error) {
+        return res.status(error.response?.status || 500).json({
+            error: error.message,
+        });
+    }
+}); */
+
+export default router;


### PR DESCRIPTION
This PR merges the `feature/code-execution` branch into `main`, completing **Phase 6: Live Preview and Code Execution** of the project. Introduces a resizable iframe-based preview panel for HTML/CSS/JavaScript, integrates Judge0 CE API for executing C, C++, Python, JavaScript, TypeScript, and Java. The implementation includes Redux slices for managing preview and execution state, input sanitization for security, and accessibility improvements.

### Completed Tasks

-   [x] Build resizable preview panel for HTML/CSS/JS output (iframe-based).
    -   Implemented a responsive, iframe-based `PreviewPanel.jsx` with resizing support using an overlay for smooth interaction.
    -   Added mobile-friendly iframe height adjustments.
-   [x] Add code execution support for C, C++, Java, Python, JS/TS using Judge0 CE API.
    -   Integrated Judge0 CE API via `judge0.js` with `fetch`, `axios` and `tanstack-query` variants.
    -   Successfully executes C (Judge0 ID: JID 50), C++ (JID 54), Java(JID 62), Python (ID 71), JavaScript (ID 63) and TypeScript (JID 74) with status, execution params, output/errors displayed in a console div.
-   [x] Configure `vite.config.js` to proxy `/api` requests to a local Node.js server (only in dev) and then to Judge0 and use Vercel functions after deployment.
    -   Set up proxy in `vite.config.js` for development and Vercel functions for production.
    -   Secured API key handling via environment variables.
-   [x] Create Redux slices for preview/compiler states.
    -   Created `executionSlice.js` to manage `output`, `error`, `isRunning`, `time`, `memory`, and `status` in compiler mode.
    -   Created `previewSlice.js` for `html`, `css`, `js`, `consoleLogs` etc. in preview mode.
-   [x] Add a "Run Code" button to execute code and display output/errors in a `<pre>` element.
    -   Added "Run Code" logic in `useEditorActions.js` to trigger `handleRunCode` in compiler mode.
    -   Replaced `<pre>` with a styled console div in `PreviewPanel.jsx` for better UX.
-   [x] Add accessibility: ARIA labels for preview and output.
    -   Added ARIA labels (`aria-label="Live code preview"`, `aria-label="JavaScript console output"`, `aria-live="polite"`) to `PreviewPanel.jsx`.
    -   Ensured resizable separator has `role="separator"` and `aria-label="Resize console panel"`.
-   [ ] Write unit tests for preview rendering and code execution. **Deferred** to a future phase due to time constraints.
-   [x] Purify user input for preview mode.
    -   Used `DOMPurify` to sanitize `html`, `css`, `js`, and `<script>` tags in HTML inputs, preventing XSS (e.g., removed `onerror=alert('XSS!')`).
-   [x] Document with JSDoc.
    -   Added JSDoc to `judge0.js` functions (`executeCodeFetch`, `executeCodeAxios`, `useExecuteCode`) and `useEditorActions.js`.

### HTML/CSS/JS Preview

-   [x] Build a resizable iframe-based preview panel.
    -   Implemented `PreviewPanel.jsx` with `useRef` for iframe management and `useMemo` to optimize content generation.
    -   Fixed iframe flicker by using `setTimeout` for `srcdoc` updates.
-   [x] Combine HTML/CSS/JS from the editor state and render in the iframe.
    -   Used `DOMParser` to extract `<body>` content, storing in `previewSlice.js` (`html`).
    -   Parsed `<script>` tags from HTML inputs for execution, sanitized with `DOMPurify`.
-   [x] Add error handling for JavaScript errors.
    -   Overrode `window.onerror` and `console.log/error/warn` in the iframe to capture errors and logs via `postMessage`.
    -   Fixed console log issues by adding `"null"` to `allowedOrigins` and correcting payload parsing.

### C/C++ and Python Execution

-   [x] Integrate Judge0 CE API for code execution (C, C++, Java, Python, JS, TS).
    -   Configured `judge0.js` to send base64-encoded `source_code` and `stdin` to `/api/submissions`.
    -   Polled submission status with retries for reliable execution.
-   [x] Display output/errors in a `<pre>` element below the editor.
    -   Replaced `<pre>` with a console div in `PreviewPanel.jsx` for better styling and accessibility.
-   [x] Creat executionSlice to manage execution state (output, error, isRunning and other judge0 data).
    -   Created `executionSlice.js` for Judge0-specific states (`output`, `error`, `time`, `memory`, `status`).
    -   Updated `previewSlice.js` for client-side console logs and visibility.

### Additional Enhancements

-   **JavaScript/TypeScript Support**:
    -   Added client-side execution in `PreviewPanel.jsx` for JavaScript.
    -   Fixed TLE for JS and TS by disabling `enable_per_process_and_thread_memory_limit` and adding retry logic (3 attempts) in `judge0.js`.
-   **Java Support**:
    -   Fixed Metaspace error (`Could not allocate metaspace: 1073741824 bytes`) by disabling `enable_per_process_and_thread_memory_limit` in `judge0Config.js`.
-   **Monaco Editor Enhancements**:

-   **Security**:
    -   Ensured `DOMPurify` sanitizes all user inputs, including `<script>` tags in HTML.
    -   Improved origin validation in `PreviewPanel.jsx` for `null` (srcdoc iframes) and production URLs.
-   **Mobile Support**:
    -   Adjusted iframe height for mobile in `PreviewPanel.jsx`.

### Known Issues

-   **Unit Tests**: Deferred to a future phase. Consider adding tests for `PreviewPanel.jsx` rendering and `judge0.js` API calls in the next sprint.
-   **Langauge Formatting/Intellisense**: No client-side formatter and intellisense available for langs other than JS and TS; relies on Judge0 for execution only. Consider using an Language Server Protocol (LSP) in the future.

### Testing

-   **Manual Tests**:
    -   Verified HTML/CSS/JS preview in `PreviewPanel.jsx` with sanitized inputs.
    -   Tested C, C++, Java, Python, JS and TS execution with Judge0, confirming correct output.
    -   Fixed and tested JavaScript/TypeScript TLE.
    -   Fixed Java execution error.
    -   Confirmed accessibility with ARIA labels.
-   **Environment**:
    -   Local: `http://localhost:5173` with proxied Judge0 API.
    -   Production: `https://bytetogether.vercel.app` with Vercel functions.
